### PR TITLE
fix: skip editor side-effects during IME composition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.IMAGE_PREFIX }}/${{ matrix.component }}
+          flavor: |
+            latest=false
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=beta,enable=${{ github.ref == 'refs/heads/beta' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI/CD
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, beta ]
     tags: ['v*']
     paths-ignore:
       - '**.md'
@@ -126,7 +126,7 @@ jobs:
     if: |
       always() &&
       github.event_name != 'pull_request' &&
-      (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) &&
+      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta' || startsWith(github.ref, 'refs/tags/v')) &&
       (startsWith(github.ref, 'refs/tags/v') ||
         needs.changes.outputs.backend == 'true' ||
         needs.changes.outputs.frontend == 'true') &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,8 @@ jobs:
         with:
           images: ${{ env.IMAGE_PREFIX }}/${{ matrix.component }}
           tags: |
-            type=ref,event=branch
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=beta,enable=${{ github.ref == 'refs/heads/beta' }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=

--- a/frontend/src/components/Editor/Editor.jsx
+++ b/frontend/src/components/Editor/Editor.jsx
@@ -136,6 +136,7 @@ class SlashMenuView {
       content: this.content,
       debounce: 50,
       shouldShow: (view) => {
+        if (view.composing) return false
         const currentText = this.provider.getContent(
           view,
           (node) => ['paragraph', 'heading'].includes(node.type.name)
@@ -230,6 +231,9 @@ class SlashMenuView {
   update(view) {
     this.view = view
     this.editorViewRef.current = view
+    // Don't query or mutate menu state mid-IME — coordsAtPos / DOM writes
+    // triggered here can drop in-flight composition characters on Windows.
+    if (view.composing) return
     this.provider.update(view)
   }
 
@@ -453,6 +457,10 @@ const Editor = forwardRef(function Editor({ defaultValue = '', onChange, onDrawi
           return {
             update(view) {
               wikilinkMenu._view = view
+              // Bail during IME composition: coordsAtPos + DOM writes from
+              // show()/hide() can disturb the active composition on Windows,
+              // making characters disappear and the cursor jump.
+              if (view.composing) return
               const { state } = view
               const { selection } = state
               if (!(selection instanceof TextSelection)) {
@@ -516,6 +524,12 @@ const Editor = forwardRef(function Editor({ defaultValue = '', onChange, onDrawi
           ctx.set(rootCtx, containerRef.current)
           ctx.set(defaultValueCtx, defaultValue)
           ctx.get(listenerCtx).markdownUpdated((_ctx, markdown) => {
+            // Skip parent state updates while IME composition is active —
+            // the React re-render they trigger can interrupt composition on
+            // Windows. ProseMirror dispatches a final transaction at
+            // compositionend, which fires the listener again with the
+            // committed text, so no input is lost.
+            if (editorViewRef.current?.composing) return
             onChangeRef.current?.(markdown)
           })
           let slashMenuView = null


### PR DESCRIPTION
Typing Chinese with the Windows IME caused characters to disappear and the cursor to jump because our custom plugins ran their update hooks during composition: the wikilink view update calls coordsAtPos and mutates an external menu element, the slash menu's shouldShow walks the doc and rebuilds the menu DOM, and the markdown listener fires setContent on the parent — each of which can interrupt the IME and make ProseMirror discard the in-flight composition.

Skip all four call sites when view.composing is true. ProseMirror dispatches a transaction at compositionend, so menus and parent state catch up with the committed text on the next update.

https://claude.ai/code/session_012rsJRUue9w7sBD3J5gmKWK