### PR TITLE
Configure ESLint to ignore underscore-prefixed function arguments

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -23,7 +23,7 @@ export default defineConfig([
       },
     },
     rules: {
-      'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
+      'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]', argsIgnorePattern: '^_' }],
     },
   },
 ])


### PR DESCRIPTION
## Summary
Updated the ESLint `no-unused-vars` rule configuration to ignore function arguments that start with an underscore, following a common convention for intentionally unused parameters.

## Changes
- Added `argsIgnorePattern: '^_'` to the `no-unused-vars` rule in `frontend/eslint.config.js`
- This allows developers to prefix unused function parameters with `_` (e.g., `(_unused) => { ... }`) to signal intent and suppress linting warnings

## Details
This is a common JavaScript convention where underscore-prefixed identifiers indicate intentionally unused variables. The existing configuration already ignored uppercase and underscore-prefixed variable names (`varsIgnorePattern: '^[A-Z_]'`); this change extends that pattern to function arguments for consistency.

https://claude.ai/code/session_01KndTBoSS4psob1CTs9q5cs