### PR TITLE
Fix IME composition Enter key handling on Windows

### DIFF
--- a/frontend/src/components/Editor/Editor.jsx
+++ b/frontend/src/components/Editor/Editor.jsx
@@ -16,6 +16,7 @@ import { mention } from './mention'
 import { math, mathBlockSchema } from './math'
 import { tableTooltip } from './tableTooltip'
 import { tablePasteExpand } from './tablePasteExpand'
+import { isStrayPostCompositionEnter } from './imeGuard'
 
 const SLASH_ITEM_DEFS = [
   { id: 'h1', icon: 'H1' },
@@ -801,32 +802,24 @@ const Editor = forwardRef(function Editor({ defaultValue = '', onChange, onDrawi
       })
     })
 
-    // On Windows, compositionend fires before the keydown for the Enter that
-    // confirmed the IME selection. By the time handleKeyDown runs, both
-    // event.isComposing and view.composing are false, so ProseMirror's default
-    // Enter handler creates a spurious newline (causing the "line shifts down"
-    // symptom). Track composition state via DOM events and clear the flag one
-    // microtask later so that post-composition Enter keydown is suppressed.
+    // On Windows, the Enter that confirms an IME selection can surface as a
+    // stray keydown fired right after compositionend (isComposing already
+    // false), which ProseMirror's default Enter handler would turn into a
+    // spurious block split. Suppress only that stray Enter — scoped to a
+    // short window after compositionend — and never an Enter that is still
+    // part of an active composition (see imeGuard.js for the rationale).
     const compositionGuardPlugin = $prose(() => {
-      let _imeComposing = false
+      let lastCompositionEndAt = 0
       return new Plugin({
         props: {
           handleDOMEvents: {
-            compositionstart(_view, _event) {
-              _imeComposing = true
-              return false
-            },
             compositionend(_view, _event) {
-              // setTimeout(0) rather than Promise microtask — on Windows the
-              // post-composition Enter keydown may arrive in the same task after
-              // compositionend, and microtasks run within that same task before
-              // the next macrotask, making the delay insufficient.
-              setTimeout(() => { _imeComposing = false }, 0)
+              lastCompositionEndAt = performance.now()
               return false
             },
           },
           handleKeyDown(_view, event) {
-            if (_imeComposing && event.key === 'Enter') {
+            if (isStrayPostCompositionEnter(event, lastCompositionEndAt, performance.now())) {
               event.preventDefault()
               return true
             }

--- a/frontend/src/components/Editor/Editor.jsx
+++ b/frontend/src/components/Editor/Editor.jsx
@@ -16,7 +16,7 @@ import { mention } from './mention'
 import { math, mathBlockSchema } from './math'
 import { tableTooltip } from './tableTooltip'
 import { tablePasteExpand } from './tablePasteExpand'
-import { isStrayPostCompositionEnter } from './imeGuard'
+import { isStrayPostCompositionEnter, NO_COMPOSITION } from './imeGuard'
 
 const SLASH_ITEM_DEFS = [
   { id: 'h1', icon: 'H1' },
@@ -809,7 +809,7 @@ const Editor = forwardRef(function Editor({ defaultValue = '', onChange, onDrawi
     // short window after compositionend — and never an Enter that is still
     // part of an active composition (see imeGuard.js for the rationale).
     const compositionGuardPlugin = $prose(() => {
-      let lastCompositionEndAt = 0
+      let lastCompositionEndAt = NO_COMPOSITION
       return new Plugin({
         props: {
           handleDOMEvents: {

--- a/frontend/src/components/Editor/imeGuard.js
+++ b/frontend/src/components/Editor/imeGuard.js
@@ -1,0 +1,22 @@
+// Window (ms) after `compositionend` during which a *stray* Enter keydown
+// is suppressed. On Windows, the Enter that confirms an IME selection can
+// surface as an extra keydown fired right after `compositionend` (with
+// `isComposing` already false); ProseMirror's default Enter handler would
+// turn that into a spurious block split ("the line shifts down"). That
+// stray Enter is part of the same physical keypress as the IME confirm, so
+// it lands within a few ms — a deliberate newline is a separate, much
+// later keypress, so a short window cleanly separates the two.
+export const POST_COMPOSITION_ENTER_MS = 50
+
+// Pure decision: should this keydown be swallowed as a post-composition
+// stray Enter? `lastCompositionEndAt` is the timestamp of the most recent
+// `compositionend` (0 if none yet); `now` is the current timestamp.
+export function isStrayPostCompositionEnter(event, lastCompositionEndAt, now) {
+  // An Enter that is still part of an active composition (e.g. Zhuyin
+  // pressing Enter to commit bopomofo into Han characters) MUST reach the
+  // IME. Never preventDefault it, or the IME can't finalize the conversion
+  // and commits the raw phonetic buffer instead of the converted text.
+  if (event.isComposing || event.keyCode === 229) return false
+  if (event.key !== 'Enter') return false
+  return now - lastCompositionEndAt <= POST_COMPOSITION_ENTER_MS
+}

--- a/frontend/src/components/Editor/imeGuard.js
+++ b/frontend/src/components/Editor/imeGuard.js
@@ -8,9 +8,16 @@
 // later keypress, so a short window cleanly separates the two.
 export const POST_COMPOSITION_ENTER_MS = 50
 
+// Sentinel for "no compositionend has happened yet". Must be -Infinity, not
+// 0: timestamps are `performance.now()` (ms since page load), so a 0
+// sentinel would falsely fall inside the window during the first
+// POST_COMPOSITION_ENTER_MS after load and swallow a plain Enter.
+export const NO_COMPOSITION = Number.NEGATIVE_INFINITY
+
 // Pure decision: should this keydown be swallowed as a post-composition
 // stray Enter? `lastCompositionEndAt` is the timestamp of the most recent
-// `compositionend` (0 if none yet); `now` is the current timestamp.
+// `compositionend` (NO_COMPOSITION if none yet); `now` is the current
+// timestamp (same clock as `lastCompositionEndAt`).
 export function isStrayPostCompositionEnter(event, lastCompositionEndAt, now) {
   // An Enter that is still part of an active composition (e.g. Zhuyin
   // pressing Enter to commit bopomofo into Han characters) MUST reach the

--- a/frontend/src/components/Editor/imeGuard.test.js
+++ b/frontend/src/components/Editor/imeGuard.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { isStrayPostCompositionEnter, POST_COMPOSITION_ENTER_MS } from './imeGuard'
+import { isStrayPostCompositionEnter, POST_COMPOSITION_ENTER_MS, NO_COMPOSITION } from './imeGuard'
 
 const enter = (overrides = {}) => ({ key: 'Enter', keyCode: 13, isComposing: false, ...overrides })
 
@@ -31,7 +31,13 @@ describe('isStrayPostCompositionEnter', () => {
   })
 
   it('does NOT suppress Enter when no composition has happened yet', () => {
-    expect(isStrayPostCompositionEnter(enter(), 0, 999999)).toBe(false)
+    expect(isStrayPostCompositionEnter(enter(), NO_COMPOSITION, 999999)).toBe(false)
+  })
+
+  it('does NOT suppress a plain Enter pressed within 50ms of page load', () => {
+    // Regression: a 0 sentinel + performance.now()-based `now` would make
+    // `now - 0 <= 50` true during the first 50ms after the time origin.
+    expect(isStrayPostCompositionEnter(enter(), NO_COMPOSITION, 12)).toBe(false)
   })
 
   it('ignores non-Enter keys even right after compositionend', () => {

--- a/frontend/src/components/Editor/imeGuard.test.js
+++ b/frontend/src/components/Editor/imeGuard.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { isStrayPostCompositionEnter, POST_COMPOSITION_ENTER_MS } from './imeGuard'
+
+const enter = (overrides = {}) => ({ key: 'Enter', keyCode: 13, isComposing: false, ...overrides })
+
+describe('isStrayPostCompositionEnter', () => {
+  it('suppresses a stray Enter fired right after compositionend', () => {
+    expect(isStrayPostCompositionEnter(enter(), 1000, 1001)).toBe(true)
+  })
+
+  it('suppresses at the exact end of the window (inclusive)', () => {
+    expect(
+      isStrayPostCompositionEnter(enter(), 1000, 1000 + POST_COMPOSITION_ENTER_MS),
+    ).toBe(true)
+  })
+
+  it('does NOT suppress an Enter that is still part of composition (isComposing)', () => {
+    // Zhuyin pressing Enter to commit bopomofo->Han: must reach the IME or
+    // the raw phonetic buffer gets dumped instead of the converted text.
+    expect(isStrayPostCompositionEnter(enter({ isComposing: true }), 1000, 1001)).toBe(false)
+  })
+
+  it('does NOT suppress an Enter delivered to the IME (keyCode 229)', () => {
+    expect(isStrayPostCompositionEnter(enter({ keyCode: 229 }), 1000, 1001)).toBe(false)
+  })
+
+  it('does NOT suppress a deliberate Enter long after compositionend', () => {
+    expect(
+      isStrayPostCompositionEnter(enter(), 1000, 1000 + POST_COMPOSITION_ENTER_MS + 1),
+    ).toBe(false)
+  })
+
+  it('does NOT suppress Enter when no composition has happened yet', () => {
+    expect(isStrayPostCompositionEnter(enter(), 0, 999999)).toBe(false)
+  })
+
+  it('ignores non-Enter keys even right after compositionend', () => {
+    expect(isStrayPostCompositionEnter({ key: 'a', keyCode: 65, isComposing: false }, 1000, 1001)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes a bug where pressing Enter to confirm an IME selection on Windows would trigger a spurious block split in the editor, causing the "line shifts down" symptom. The issue occurs because Windows fires a stray `keydown` event for Enter right after `compositionend`, which ProseMirror's default handler interprets as a deliberate newline.

## Changes

- **New module `imeGuard.js`**: Implements `isStrayPostCompositionEnter()` to detect and suppress only the stray Enter that arrives within 50ms of `compositionend`. The logic carefully preserves Enters that are still part of an active composition (e.g., Zhuyin pressing Enter to commit phonetic input) and those delivered to the IME itself (keyCode 229).

- **New test file `imeGuard.test.js`**: Comprehensive test suite covering:
  - Suppression of stray Enter within the 50ms window
  - Preservation of Enters during active composition
  - Preservation of Enters delivered to the IME
  - Rejection of Enters outside the window
  - Edge case: regression test for the NO_COMPOSITION sentinel to prevent false positives during page load

- **Updated `Editor.jsx`**: Replaced the previous composition guard logic with a cleaner implementation:
  - Removed the `compositionstart` handler (no longer needed)
  - Changed `compositionend` to record a timestamp (`lastCompositionEndAt`) instead of setting a boolean flag
  - Replaced the boolean check with a call to `isStrayPostCompositionEnter()` that uses the timestamp window
  - Removed the `setTimeout(0)` workaround in favor of a time-based window

## Implementation Details

- Uses `performance.now()` for precise timing, consistent with the timestamp recorded at `compositionend`
- The 50ms window is short enough to catch the stray Enter (typically arrives within a few ms) but long enough to avoid false positives from deliberate newlines
- The `NO_COMPOSITION` sentinel is `Number.NEGATIVE_INFINITY` to prevent false positives during the first 50ms after page load (when `performance.now()` is small)
- Respects IME-specific requirements: never suppresses Enters with `isComposing: true` or `keyCode: 229`, as these are part of the IME's input flow

https://claude.ai/code/session_01KT7qFP6oQ5GdiotRi7X5De