### PR TITLE
Security hardening, correctness fixes, and webhook support

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -91,7 +91,7 @@ async def _resolve_api_token(token: str) -> dict | None:
     rows = await db.execute_fetchall(
         """SELECT t.id, t.expires_at, t.revoked_at,
                   u.id AS user_id, u.username, u.role, u.display_name, u.email,
-                  u.deleted_at
+                  u.deleted_at, u.is_active
            FROM api_tokens t
            JOIN users u ON u.id = t.user_id
            WHERE t.token_hash = ?""",
@@ -100,7 +100,8 @@ async def _resolve_api_token(token: str) -> dict | None:
     if not rows:
         return None
     row = dict(rows[0])
-    if row["deleted_at"] is not None or row["revoked_at"] is not None:
+    # A deactivated or deleted owner invalidates the token immediately.
+    if row["deleted_at"] is not None or row["revoked_at"] is not None or not row["is_active"]:
         return None
     if row["expires_at"] is not None:
         # SQLite stores these as strings; parse tolerantly so 'YYYY-MM-DD HH:MM:SS'
@@ -160,7 +161,8 @@ async def resolve_request_credentials(request: Request) -> dict | None:
 
     db = await get_db()
     row = await db.execute_fetchall(
-        "SELECT id, username, role, display_name, email FROM users WHERE id = ? AND deleted_at IS NULL",
+        "SELECT id, username, role, display_name, email FROM users "
+        "WHERE id = ? AND deleted_at IS NULL AND is_active = 1",
         (user_id,),
     )
     if not row:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -25,10 +25,17 @@ class Settings(BaseSettings):
     # When deployed behind a reverse proxy (nginx/Caddy/ALB/Traefik), the
     # direct TCP peer is the proxy — rate limiters keyed on `request.client.host`
     # then see every client as the same IP and either deny everyone or no-one.
-    # Setting this to True makes the rate limiters trust the left-most
-    # `X-Forwarded-For` entry. Only enable this when a trusted proxy is
-    # actually in front of the app; otherwise a client can spoof the header.
+    # Setting this to True makes the rate limiters read the client IP from
+    # `X-Forwarded-For`. Only enable this when a trusted proxy is actually in
+    # front of the app; otherwise a client can spoof the header.
     TRUST_PROXY: bool = False
+
+    # Number of trusted reverse-proxy hops in front of the app. The client IP
+    # is taken as the Nth-from-the-right `X-Forwarded-For` entry — the leftmost
+    # entries are client-supplied and MUST NOT be trusted. For a single nginx
+    # doing `proxy_add_x_forwarded_for`, the rightmost entry is the real client,
+    # so the default of 1 is correct. Increase only if you chain more proxies.
+    TRUST_PROXY_HOPS: int = 1
 
     # Public base URL the browser can reach. Used to build OIDC redirect_uri
     # and SSO-error redirects. In dev leave as localhost:8000; in prod set to

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -31,6 +31,7 @@ CREATE TABLE IF NOT EXISTS users (
     email             TEXT DEFAULT '',
     bio               TEXT NOT NULL DEFAULT '',
     original_username TEXT,
+    is_active         INTEGER NOT NULL DEFAULT 1,
     deleted_at        TIMESTAMP,
     created_at        TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
@@ -1321,20 +1322,25 @@ async def _ensure_fts5_index(db) -> bool:
         create_sql = rows[0]["sql"] or ""
         match = _TOKENIZE_RE.search(create_sql)
         current = match.group(1).lower() if match else None
+        # page_id must be UNINDEXED — otherwise it's part of the full-text
+        # index and a numeric query (e.g. "100") matches page ids via their
+        # trigrams, returning irrelevant pages. Older DBs created it indexed.
+        page_id_unindexed = "page_id unindexed" in create_sql.lower()
 
-        if current == preferred:
-            return False  # Already using the right tokenizer
+        if current == preferred and page_id_unindexed:
+            return False  # Already correct — right tokenizer, page_id excluded
 
         logger.info(
-            "Migrating search_index tokenizer from '%s' to '%s' …",
+            "Migrating search_index (tokenizer '%s'→'%s', page_id UNINDEXED=%s) …",
             current or "unknown",
             preferred,
+            page_id_unindexed,
         )
         await db.execute("DROP TABLE IF EXISTS search_index")
 
     await db.execute(
         f"CREATE VIRTUAL TABLE IF NOT EXISTS search_index USING fts5("
-        f"page_id, title, content_segmented, tokenize='{preferred}')"
+        f"page_id UNINDEXED, title, content_segmented, tokenize='{preferred}')"
     )
     await db.commit()
     logger.info("FTS5 search_index ready (tokenizer=%s)", preferred)
@@ -1704,7 +1710,9 @@ async def rebuild_all_search_indexes(db):
     if rows[0]["cnt"] > 0:
         return  # Already populated
 
-    pages = await db.execute_fetchall("SELECT id, title, content_md FROM pages")
+    pages = await db.execute_fetchall(
+        "SELECT id, title, content_md FROM pages WHERE deleted_at IS NULL"
+    )
     for p in pages:
         await rebuild_search_index(db, p["id"], p["title"], p["content_md"])
     if pages:
@@ -1719,7 +1727,9 @@ async def rebuild_all_backlinks(db):
     if rows[0]["cnt"] > 0:
         return  # Already populated
 
-    pages = await db.execute_fetchall("SELECT id, content_md FROM pages")
+    pages = await db.execute_fetchall(
+        "SELECT id, content_md FROM pages WHERE deleted_at IS NULL"
+    )
     for p in pages:
         await parse_and_update_backlinks(db, p["id"], p["content_md"])
     if pages:
@@ -1741,7 +1751,9 @@ async def rebuild_all_media_refs(db):
     if current & 0x1:
         return
 
-    pages = await db.execute_fetchall("SELECT id, content_md FROM pages")
+    pages = await db.execute_fetchall(
+        "SELECT id, content_md FROM pages WHERE deleted_at IS NULL"
+    )
     for p in pages:
         await parse_and_update_media_refs(db, p["id"], p["content_md"])
     await db.execute(f"PRAGMA user_version = {current | 0x1}")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -28,27 +28,71 @@ _SAFE_METHODS = {"GET", "HEAD", "OPTIONS"}
 _CSRF_EXEMPT_PATHS = {"/api/auth/login", "/api/auth/logout"}
 
 _INSECURE_SECRETS = {"change-me-to-random-string", "secret", ""}
+_WEAK_ADMIN_PASSWORDS = {"admin", "password", "123456", ""}
+
+
+def _looks_production() -> bool:
+    """Heuristic for "this instance is being exposed, not run locally".
+
+    True when any config signals a real deployment: secure cookies are on,
+    the public URL is not localhost, or explicit allowed origins were set.
+    Pure localhost dev (the defaults) returns False so `make dev` keeps
+    working out of the box with only a loud warning.
+    """
+    url = settings.PUBLIC_BASE_URL
+    not_localhost = not (
+        url.startswith("http://localhost")
+        or url.startswith("http://127.0.0.1")
+    )
+    return settings.COOKIE_SECURE or not_localhost or bool(settings.ALLOWED_ORIGINS.strip())
 
 
 def _check_security():
-    """Warn loudly about insecure defaults on startup."""
+    """Warn on insecure defaults; refuse to start on a production-looking one.
+
+    Insecure defaults are tolerated (with a loud warning) for localhost dev,
+    but a deployment that looks internet-facing must not boot with a forgeable
+    SECRET_KEY or a guessable admin password — fail closed instead.
+    """
+    fatal: list[str] = []
+    production = _looks_production()
+
     if settings.SECRET_KEY.get_secret_value() in _INSECURE_SECRETS:
         safe_key = secrets.token_urlsafe(32)
-        logger.critical(
-            "\n"
-            "╔══════════════════════════════════════════════════════╗\n"
-            "║  ⚠  SECRET_KEY is set to an insecure default!      ║\n"
-            "║  Anyone can forge JWT tokens with this key.         ║\n"
-            "║  Set SECRET_KEY in .env to a random value, e.g.:   ║\n"
-            "║  SECRET_KEY=%s  ║\n"
-            "╚══════════════════════════════════════════════════════╝",
-            safe_key[:44],
-        )
+        if production:
+            fatal.append(
+                "SECRET_KEY is set to an insecure default — anyone can forge "
+                f"JWT tokens. Set SECRET_KEY in .env to a random value, e.g.: {safe_key}"
+            )
+        else:
+            logger.critical(
+                "\n"
+                "╔══════════════════════════════════════════════════════╗\n"
+                "║  ⚠  SECRET_KEY is set to an insecure default!      ║\n"
+                "║  Anyone can forge JWT tokens with this key.         ║\n"
+                "║  Set SECRET_KEY in .env to a random value, e.g.:   ║\n"
+                "║  SECRET_KEY=%s  ║\n"
+                "╚══════════════════════════════════════════════════════╝",
+                safe_key[:44],
+            )
     admin_pass = settings.ADMIN_PASS.get_secret_value()
-    if admin_pass in {"admin", "password", "123456", ""}:
-        logger.warning(
-            "ADMIN_PASS is set to a weak default. "
-            "Change it in .env before deploying to production.",
+    if admin_pass in _WEAK_ADMIN_PASSWORDS:
+        if production:
+            fatal.append(
+                "ADMIN_PASS is set to a weak default. Set a strong ADMIN_PASS "
+                "in .env before exposing the app."
+            )
+        else:
+            logger.warning(
+                "ADMIN_PASS is set to a weak default. "
+                "Change it in .env before deploying to production.",
+            )
+
+    if fatal:
+        raise RuntimeError(
+            "Refusing to start with insecure configuration:\n  - "
+            + "\n  - ".join(fatal)
+            + "\nThese are tolerated only for localhost development."
         )
     # Either SSO path issues the session cookie (OIDC state/nonce/PKCE) over
     # the wire. Without TLS marking, a passive attacker on the path can
@@ -190,8 +234,17 @@ async def csrf_guard(request: Request, call_next):
         except ValueError:
             return None
 
+    def _is_localhost(url: str | None) -> bool:
+        # Exact host match, not a prefix — startswith("http://localhost")
+        # would wrongly accept attacker origins like http://localhost.evil.com.
+        if not url:
+            return False
+        from urllib.parse import urlsplit
+
+        return urlsplit(url).hostname in ("localhost", "127.0.0.1")
+
     candidate = origin or _origin_of(referer)
-    is_localhost = candidate is not None and candidate.startswith("http://localhost")
+    is_localhost = _is_localhost(candidate)
     if not is_localhost and candidate not in _ALLOWED_ORIGINS:
         return JSONResponse(
             status_code=403,

--- a/backend/app/migrations.py
+++ b/backend/app/migrations.py
@@ -189,6 +189,20 @@ async def _m012_user_bio(db: aiosqlite.Connection) -> None:
         await db.execute("ALTER TABLE users ADD COLUMN bio TEXT NOT NULL DEFAULT ''")
 
 
+async def _m013_user_is_active(db: aiosqlite.Connection) -> None:
+    """Add `is_active` to users so an account can be suspended without deleting.
+
+    NOT NULL DEFAULT 1 so every existing user stays enabled after the upgrade.
+    A deactivated user (is_active=0) is rejected at login and on every
+    credential check, but the row (and their content/history) is untouched —
+    distinct from soft-delete, which tombstones the account.
+    """
+    if not await _column_exists(db, "users", "is_active"):
+        await db.execute(
+            "ALTER TABLE users ADD COLUMN is_active INTEGER NOT NULL DEFAULT 1"
+        )
+
+
 MIGRATIONS: list[Migration] = [
     (1, "user_profile_columns", _m001_user_profile_columns),
     (2, "user_soft_delete", _m002_user_soft_delete),
@@ -202,6 +216,7 @@ MIGRATIONS: list[Migration] = [
     (10, "site_settings", _m010_site_settings),
     (11, "mindmap_layout", _m011_mindmap_layout),
     (12, "user_bio", _m012_user_bio),
+    (13, "user_is_active", _m013_user_is_active),
 ]
 
 

--- a/backend/app/routers/activity.py
+++ b/backend/app/routers/activity.py
@@ -17,22 +17,25 @@ async def log_activity(db, user_id: int, action: str, target_type: str, target_i
     )
 
 
-def _readable_clause(readable: frozenset[int] | set[int]) -> tuple[str, list]:
-    """SQL fragment + params for "target_type='page' AND target_id ∈ readable".
+def _readable_clause(
+    readable: frozenset[int] | set[int], is_admin: bool
+) -> tuple[str, list]:
+    """SQL fragment + params scoping the activity feed to the caller.
 
-    Non-page rows (e.g. comment activity) are kept as-is — currently every
-    write that calls log_activity uses target_type='page', so the filter is
-    effectively a whitelist; if non-page targets are added later, they'll
-    pass through and may need their own ACL gate.
+    Non-admins see ONLY page activity for pages they can read. Non-page rows
+    (group create/delete + membership, api_token create/revoke, ACL changes)
+    carry org-structure and credential-lifecycle metadata, so they are
+    admin-only — otherwise any authenticated user (or an anonymous visitor
+    under ANONYMOUS_READ) could enumerate group names, who was added/removed
+    from which group, and other users' token names via /api/activity.
     """
+    if is_admin:
+        return "1 = 1", []
     if not readable:
-        # No readable pages → drop every page-targeted row.
-        return "(a.target_type != 'page')", []
+        # No readable pages and not admin → nothing to show.
+        return "0 = 1", []
     id_clause, id_params = build_id_clause(readable, column="a.target_id")
-    return (
-        f"(a.target_type != 'page' OR {id_clause})",
-        id_params,
-    )
+    return (f"(a.target_type = 'page' AND {id_clause})", id_params)
 
 
 @router.get("")
@@ -46,9 +49,10 @@ async def list_activity(
 
     # Filter activity to entries about pages the caller can read; otherwise
     # the feed leaks titles/slugs of restricted pages via the metadata blob.
-    # Admin is short-circuited inside list_readable_page_ids.
+    # Admins additionally see non-page (group/token/ACL) activity.
+    is_admin = user.get("role") == "admin"
     readable = await list_readable_page_ids(db, user)
-    where_sql, where_params = _readable_clause(readable)
+    where_sql, where_params = _readable_clause(readable, is_admin)
 
     count_rows = await db.execute_fetchall(
         f"SELECT COUNT(*) as cnt FROM activity_log a WHERE {where_sql}",
@@ -121,7 +125,11 @@ async def activity_stats(user=Depends(get_current_user)):
         f"""SELECT p.id, p.slug, p.title, p.view_count
            FROM pages p
            WHERE {p_id_clause}
-             AND p.id NOT IN (SELECT target_page_id FROM backlinks)
+             AND p.id NOT IN (
+                 SELECT b.target_page_id FROM backlinks b
+                 JOIN pages sp ON sp.id = b.source_page_id
+                 WHERE sp.deleted_at IS NULL
+             )
              AND p.parent_id IS NULL
            ORDER BY p.updated_at DESC LIMIT 20""",
         p_id_params,

--- a/backend/app/routers/auth_router.py
+++ b/backend/app/routers/auth_router.py
@@ -22,10 +22,14 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/auth", tags=["auth"])
 
-# Simple in-memory rate limiter for login: max 5 attempts per IP per 60 seconds
-_login_attempts: dict[str, list[float]] = defaultdict(list)
+# Simple in-memory rate limiter for login: max 5 attempts per IP per 60 seconds.
+# Memory is bounded: emptied buckets are dropped and, past _MAX_IPS, the
+# oldest-touched entries are evicted so an IP-rotating attacker can't leak the
+# dict linearly.
+_login_attempts: dict[str, list[float]] = {}
 _RATE_LIMIT_MAX = 5
 _RATE_LIMIT_WINDOW = 60  # seconds
+_MAX_IPS = 10_000
 
 # Pre-computed bcrypt hash for the constant-time login path. Verifying
 # against this when the username doesn't exist (or is a shell account with
@@ -36,15 +40,22 @@ _DUMMY_PASSWORD_HASH = hash_password("dummy-constant-time-guard")
 
 def _check_rate_limit(ip: str):
     now = time.monotonic()
-    attempts = _login_attempts[ip]
-    # Prune old entries
-    _login_attempts[ip] = [t for t in attempts if now - t < _RATE_LIMIT_WINDOW]
-    if len(_login_attempts[ip]) >= _RATE_LIMIT_MAX:
+    # pop+reinsert so insertion order tracks recency for the LRU eviction below.
+    attempts = _login_attempts.pop(ip, [])
+    pruned = [t for t in attempts if now - t < _RATE_LIMIT_WINDOW]
+    if len(pruned) >= _RATE_LIMIT_MAX:
+        _login_attempts[ip] = pruned
         raise HTTPException(
             status_code=429,
             detail="Too many login attempts. Please wait before trying again.",
         )
-    _login_attempts[ip].append(now)
+    pruned.append(now)
+    _login_attempts[ip] = pruned
+
+    if len(_login_attempts) > _MAX_IPS:
+        # Drop oldest-touched entries first; cheap one-shot loop only at the cap.
+        for stale in list(_login_attempts)[: len(_login_attempts) - _MAX_IPS]:
+            _login_attempts.pop(stale, None)
 
 
 @router.post("/login")
@@ -52,8 +63,12 @@ async def login(body: LoginRequest, request: Request, response: Response):
     _check_rate_limit(client_ip(request))
 
     db = await get_db()
+    # `is_active = 1` folds deactivated accounts into the same generic-failure
+    # path as a wrong username, so login stays timing-safe and doesn't reveal
+    # whether an account exists-but-suspended.
     rows = await db.execute_fetchall(
-        "SELECT id, username, password_hash, role, display_name, email FROM users WHERE username = ? AND deleted_at IS NULL",
+        "SELECT id, username, password_hash, role, display_name, email FROM users "
+        "WHERE username = ? AND deleted_at IS NULL AND is_active = 1",
         (body.username,),
     )
 

--- a/backend/app/routers/comments.py
+++ b/backend/app/routers/comments.py
@@ -44,7 +44,7 @@ async def list_comments(
            FROM comments c
            LEFT JOIN users u ON u.id = c.user_id
            WHERE c.page_id = ?
-           ORDER BY c.created_at ASC
+           ORDER BY c.created_at ASC, c.id ASC
            LIMIT ? OFFSET ?""",
         (page_id, per_page, offset),
     )

--- a/backend/app/routers/media.py
+++ b/backend/app/routers/media.py
@@ -16,6 +16,34 @@ ALLOWED_TYPES = {
     "application/pdf", "text/plain", "text/markdown",
 }
 
+# Canonical on-disk extension per allowed MIME. The stored filename's
+# extension is derived from the *validated* content type — never from the
+# uploader-supplied filename — so a `text/plain` upload named "x.html" can't
+# be stored as `<uuid>.html` and later served as text/html (stored XSS).
+_MIME_EXT = {
+    "image/png": ".png",
+    "image/jpeg": ".jpg",
+    "image/gif": ".gif",
+    "image/webp": ".webp",
+    "image/svg+xml": ".svg",
+    "application/pdf": ".pdf",
+    "text/plain": ".txt",
+    "text/markdown": ".md",
+}
+
+# Extensions the browser may render inline, each mapped to the explicit
+# Content-Type we serve it as. Anything NOT in this set is served as a
+# download with a neutral type so it can never execute as active content
+# (HTML/SVG/script) in the app's origin.
+_INLINE_SAFE_TYPES = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".pdf": "application/pdf",
+}
+
 MAX_UPLOAD_SIZE = 20 * 1024 * 1024  # 20 MB
 
 # SVG can carry embedded scripts. We keep SVG uploads in the allow-list for
@@ -104,7 +132,11 @@ async def upload_media(
             detail="SVG upload contains scripting or event handlers",
         )
 
-    ext = Path(file.filename or "file").suffix
+    # Derive the stored extension from the validated content type, not the
+    # uploader's filename — the filename extension is attacker-controlled and
+    # drives the served Content-Type. content_type is guaranteed to be in
+    # ALLOWED_TYPES (checked above), which is exactly _MIME_EXT's keyset.
+    ext = _MIME_EXT.get(file.content_type, "")
     filename = f"{uuid.uuid4().hex}{ext}"
     filepath = Path(settings.MEDIA_DIR) / filename
 
@@ -238,16 +270,22 @@ _ALWAYS_PUBLIC_FILENAMES = {"logo.png"}
 
 
 def _safe_media_response(filepath: Path) -> FileResponse:
-    """FileResponse hardened against browsers inferring active-content from SVG.
+    """FileResponse hardened against the browser rendering active content.
 
-    SVG is the only format in the allow-list that can execute script; even
-    after upload-time filtering we serve it as an attachment with nosniff so
-    a polyglot slip-through can never run inline in the app's origin.
+    Only a fixed allow-list of image/pdf extensions is served inline, each
+    with an explicit trusted Content-Type so the browser never sniffs or
+    guesses from the (attacker-influenced) extension. Everything else —
+    SVG, text, or any unexpected extension — is served as a neutral
+    ``application/octet-stream`` attachment, so a stored file can never run
+    as HTML/SVG/script in the app's origin even if it slipped past the
+    upload-time content checks.
     """
     headers = {"X-Content-Type-Options": "nosniff"}
-    if filepath.suffix.lower() in {".svg", ".svgz"}:
-        headers["Content-Disposition"] = f'attachment; filename="{filepath.name}"'
-    return FileResponse(filepath, headers=headers)
+    inline_type = _INLINE_SAFE_TYPES.get(filepath.suffix.lower())
+    if inline_type is not None:
+        return FileResponse(filepath, media_type=inline_type, headers=headers)
+    headers["Content-Disposition"] = f'attachment; filename="{filepath.name}"'
+    return FileResponse(filepath, media_type="application/octet-stream", headers=headers)
 
 
 async def _media_is_public(db, filename: str) -> bool:

--- a/backend/app/routers/media.py
+++ b/backend/app/routers/media.py
@@ -281,9 +281,21 @@ def _safe_media_response(filepath: Path) -> FileResponse:
     upload-time content checks.
     """
     headers = {"X-Content-Type-Options": "nosniff"}
-    inline_type = _INLINE_SAFE_TYPES.get(filepath.suffix.lower())
+    ext = filepath.suffix.lower()
+    inline_type = _INLINE_SAFE_TYPES.get(ext)
     if inline_type is not None:
         return FileResponse(filepath, media_type=inline_type, headers=headers)
+    if ext == ".svg":
+        # SVG can carry script, but it only executes as a *top-level* document
+        # (direct navigation, <iframe>, <object>) — never when painted through
+        # <img>. Force an attachment disposition so navigating straight to the
+        # URL downloads instead of rendering, while still serving the explicit
+        # image/svg+xml type so legitimate `![icon](/api/media/x.svg)` embeds
+        # keep rendering in <img>.
+        headers["Content-Disposition"] = f'attachment; filename="{filepath.name}"'
+        return FileResponse(filepath, media_type="image/svg+xml", headers=headers)
+    # Everything else (text, svgz, or an unexpected extension): neutral
+    # download so it can never run as active content in the app's origin.
     headers["Content-Disposition"] = f'attachment; filename="{filepath.name}"'
     return FileResponse(filepath, media_type="application/octet-stream", headers=headers)
 

--- a/backend/app/routers/oauth_router.py
+++ b/backend/app/routers/oauth_router.py
@@ -35,7 +35,14 @@ def _safe_redirect(raw: str | None) -> str:
     """
     if not raw or not isinstance(raw, str):
         return "/"
-    if not raw.startswith("/") or raw.startswith("//"):
+    # Must be a same-origin absolute path. Reject:
+    #   - anything not starting with "/"        (absolute URLs, schemes)
+    #   - "//host"  → protocol-relative redirect
+    #   - "/\host"  → browsers normalize "\" to "/", so this becomes "//host"
+    #   - embedded backslashes / control chars used to smuggle the above
+    if not raw.startswith("/") or raw[1:2] in ("/", "\\"):
+        return "/"
+    if any(c in raw for c in ("\\", "\n", "\r", "\t")):
         return "/"
     return raw
 

--- a/backend/app/routers/pages.py
+++ b/backend/app/routers/pages.py
@@ -152,7 +152,10 @@ async def list_pages(
     total = count_row[0]["cnt"]
 
     rows = await db.execute_fetchall(
-        f"SELECT * FROM pages {where} ORDER BY sort_order, updated_at DESC LIMIT ? OFFSET ?",
+        # `id` tiebreak makes the order total — without it, pages sharing
+        # sort_order and a same-second updated_at can duplicate/skip across
+        # LIMIT/OFFSET pages.
+        f"SELECT * FROM pages {where} ORDER BY sort_order, updated_at DESC, id DESC LIMIT ? OFFSET ?",
         params + [per_page, offset],
     )
     pages = [dict(r) for r in rows]
@@ -396,6 +399,17 @@ async def update_page(
     sort_order = body.sort_order if body.sort_order is not None else current["sort_order"]
 
     if "parent_id" in body.model_fields_set and parent_id != current["parent_id"]:
+        if parent_id is not None:
+            # Validate the target parent exists and is live BEFORE hitting the
+            # FK — a nonexistent parent_id would otherwise surface as an opaque
+            # 500 (IntegrityError), and a soft-deleted parent would silently
+            # nest a live page under a trashed one.
+            parent_rows = await db.execute_fetchall(
+                "SELECT id FROM pages WHERE id = ? AND deleted_at IS NULL",
+                (parent_id,),
+            )
+            if not parent_rows:
+                raise HTTPException(status_code=400, detail="Parent page not found")
         if await _would_create_parent_cycle(db, current["id"], parent_id):
             raise HTTPException(
                 status_code=400,
@@ -422,17 +436,47 @@ async def update_page(
     # is_public / page_type changes do NOT bump version (metadata, not content)
     new_version = current["version"] + 1 if (content_changed or title_changed) else current["version"]
 
+    versioned_edit = content_changed or title_changed
     async with write_transaction(db):
         # Save current state as a version before updating (only if content/title actually changed).
         # Publicity/page_type toggles are metadata, not content, so they don't create a version.
-        if content_changed or title_changed:
+        if versioned_edit:
             await save_version(db, current["id"], current["title"], current["content_md"], user["id"])
 
-        await db.execute(
-            """UPDATE pages SET title = ?, content_md = ?, parent_id = ?, sort_order = ?,
-               is_public = ?, page_type = ?, mindmap_layout = ?, version = ?, updated_at = CURRENT_TIMESTAMP WHERE slug = ?""",
-            (title, content, parent_id, sort_order, 1 if is_public else 0, page_type, mindmap_layout, new_version, slug),
+        # Atomic optimistic lock: for a versioned edit, guard the write with
+        # `AND version = base_version` so the version check and the write are
+        # a single statement. `current["version"]` equals the base_version we
+        # validated above; if a concurrent writer bumped the row in between,
+        # this matches 0 rows and we 409 instead of silently clobbering. The
+        # pre-write comparison alone was a TOCTOU (read on a reader connection,
+        # write on the writer) that could lose a concurrent save.
+        where_sql = "WHERE slug = ?"
+        params = [
+            title, content, parent_id, sort_order, 1 if is_public else 0,
+            page_type, mindmap_layout, new_version, slug,
+        ]
+        if versioned_edit:
+            where_sql = "WHERE slug = ? AND version = ?"
+            params.append(current["version"])
+        cursor = await db.execute(
+            f"""UPDATE pages SET title = ?, content_md = ?, parent_id = ?, sort_order = ?,
+               is_public = ?, page_type = ?, mindmap_layout = ?, version = ?,
+               updated_at = CURRENT_TIMESTAMP {where_sql}""",
+            params,
         )
+        if versioned_edit and cursor.rowcount == 0:
+            latest = await db.execute_fetchall(
+                "SELECT version FROM pages WHERE slug = ?", (slug,)
+            )
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "error": "conflict",
+                    "message": "This page was modified by someone else. Reload to see the latest version.",
+                    "current_version": latest[0]["version"] if latest else None,
+                    "your_version": body.base_version,
+                },
+            )
 
         # Update search index
         await rebuild_search_index(db, current["id"], title, content)
@@ -515,6 +559,17 @@ async def move_page(
     updates = []
     params = []
     if "parent_id" in body.model_fields_set:
+        if body.parent_id is not None:
+            # Reject a nonexistent/soft-deleted destination up front. Without
+            # this, resolve_page_permission on an unknown id returns the
+            # open-default and the UPDATE then trips the FK as an opaque 500,
+            # or nests the page under a trashed parent.
+            parent_rows = await db.execute_fetchall(
+                "SELECT id FROM pages WHERE id = ? AND deleted_at IS NULL",
+                (body.parent_id,),
+            )
+            if not parent_rows:
+                raise HTTPException(status_code=400, detail="Parent page not found")
         if await _would_create_parent_cycle(db, page_id, body.parent_id):
             raise HTTPException(
                 status_code=400,

--- a/backend/app/routers/public.py
+++ b/backend/app/routers/public.py
@@ -24,10 +24,10 @@ _HTML_COMMENT_RE = re.compile(r"<!--[\s\S]*?-->")
 # on restart; an attacker who can rotate IPs (or trigger restarts) gets
 # fresh budget. Acceptable for a self-hosted small-team wiki.
 #
-# Memory: empty buckets are dropped after the prune so a one-off visitor
-# doesn't leave a permanent entry; if the dict still grows past _MAX_IPS
-# we drop the oldest-touched entries. Without this, an IP-rotating scraper
-# would leak memory linearly.
+# Memory: each active IP keeps one bucket; once the dict grows past _MAX_IPS
+# the oldest-touched entries are evicted (insertion order tracks recency via
+# the pop+reinsert below). Without this cap, an IP-rotating scraper would
+# leak memory linearly.
 _access_log: dict[str, list[float]] = defaultdict(list)
 _RATE_LIMIT_MAX = 60
 _RATE_LIMIT_WINDOW = 60  # seconds
@@ -77,13 +77,20 @@ async def get_public_page(slug: str, request: Request):
     # Strip HTML comments from source (Q8).
     page["content_md"] = _HTML_COMMENT_RE.sub("", page["content_md"])
 
-    # Inline drawio SVGs (Q3).
+    # Inline drawio SVGs (Q3). Only diagrams that live on a public, non-deleted
+    # page may be inlined — otherwise an editor could embed ::drawio[<any id>]
+    # into a public page and exfiltrate the rendered SVG of a diagram owned by
+    # a page they can't read (the authenticated path gates this by page ACL).
     ids = set(_DRAWIO_ID_RE.findall(page["content_md"]))
     diagrams: dict[str, str] = {}
     if ids:
         placeholders = ",".join("?" * len(ids))
         diag_rows = await db.execute_fetchall(
-            f"SELECT id, svg_cache FROM diagrams WHERE id IN ({placeholders})",
+            f"""SELECT d.id, d.svg_cache
+                FROM diagrams d
+                JOIN pages dp ON dp.id = d.page_id
+                WHERE d.id IN ({placeholders})
+                  AND dp.is_public = 1 AND dp.deleted_at IS NULL""",
             list(ids),
         )
         diagrams = {

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -261,7 +261,7 @@ async def list_users(
     count_rows = await db.execute_fetchall(f"SELECT COUNT(*) as cnt FROM users {where}")
     total = count_rows[0]["cnt"]
     rows = await db.execute_fetchall(
-        f"""SELECT id, username, original_username, role, deleted_at, created_at
+        f"""SELECT id, username, original_username, role, is_active, deleted_at, created_at
             FROM users {where}
             ORDER BY id LIMIT ? OFFSET ?""",
         (per_page, offset),
@@ -412,6 +412,30 @@ async def update_user(user_id: int, body: UserUpdate, user=Depends(require_admin
     if body.password is not None:
         updates.append("password_hash = ?")
         values.append(await hash_password_async(body.password))
+    if body.is_active is not None:
+        # Suspending an account (is_active=0) locks the user out on every
+        # credential path without deleting their data. Guard the same two
+        # footguns as role demotion: don't let an admin lock themselves out,
+        # and don't disable the last remaining admin.
+        if not body.is_active:
+            if user_id == user["id"]:
+                raise HTTPException(
+                    status_code=400, detail="Cannot deactivate yourself"
+                )
+            target_admin = await db.execute_fetchall(
+                "SELECT 1 FROM users WHERE id = ? AND role = 'admin'", (user_id,)
+            )
+            if target_admin:
+                admin_count = await db.execute_fetchall(
+                    "SELECT COUNT(*) as cnt FROM users "
+                    "WHERE role = 'admin' AND deleted_at IS NULL AND is_active = 1"
+                )
+                if admin_count[0]["cnt"] <= 1:
+                    raise HTTPException(
+                        status_code=400, detail="Cannot deactivate the last admin"
+                    )
+        updates.append("is_active = ?")
+        values.append(1 if body.is_active else 0)
 
     if updates:
         values.append(user_id)
@@ -421,7 +445,8 @@ async def update_user(user_id: int, body: UserUpdate, user=Depends(require_admin
             )
 
     row = await db.execute_fetchall(
-        "SELECT id, username, role, created_at FROM users WHERE id = ?", (user_id,)
+        "SELECT id, username, role, is_active, created_at FROM users WHERE id = ?",
+        (user_id,),
     )
     return dict(row[0])
 

--- a/backend/app/routers/versions.py
+++ b/backend/app/routers/versions.py
@@ -7,6 +7,8 @@ from app.services.acl import PageAccess, page_dep
 from app.services.search import rebuild_search_index
 from app.services.wikilink import parse_and_update_backlinks
 from app.services.media_ref import parse_and_update_media_refs
+from app.services.notifications import notify_page_updated
+from app.services.mention import notify_mentions
 from app.routers.activity import log_activity
 
 
@@ -130,17 +132,17 @@ async def revert_to_version(
     current = ctx.page
 
     # Optimistic lock — same contract as PUT /pages/{slug}. Reverting always
-    # changes content, so the client must pin to a known base_version. If
-    # someone else edited the page between the user opening the versions
-    # page and clicking revert, return 409 instead of silently clobbering.
-    if body.base_version is not None and body.base_version != current["version"]:
+    # changes content, so the client MUST pin to a known base_version (no
+    # silent fallback, matching update_page). If someone else edited the page
+    # between the user opening the versions list and clicking revert, we 409
+    # instead of clobbering.
+    if body.base_version is None:
         raise HTTPException(
-            status_code=409,
+            status_code=400,
             detail={
-                "error": "conflict",
-                "message": "This page was modified by someone else. Reload the versions list and try again.",
+                "error": "base_version_required",
+                "message": "base_version is required to revert.",
                 "current_version": current["version"],
-                "your_version": body.base_version,
             },
         )
 
@@ -151,17 +153,34 @@ async def revert_to_version(
     if not version:
         raise HTTPException(status_code=404, detail="Version not found")
 
+    old_content = current["content_md"]
     async with write_transaction(db):
         # Save current state as a new version before reverting
         await save_version(db, current["id"], current["title"], current["content_md"], user["id"])
 
-        # Revert — bump the optimistic lock version so concurrent editors get a 409
+        # Revert with an ATOMIC optimistic lock: guard the write with
+        # `AND version = base_version` so the check and the write are a single
+        # statement. A concurrent writer that already bumped the version makes
+        # this match 0 rows → 409, closing the TOCTOU the pre-read check had.
         new_version = current["version"] + 1
-        await db.execute(
+        cursor = await db.execute(
             """UPDATE pages SET title = ?, content_md = ?, version = ?,
-               updated_at = CURRENT_TIMESTAMP WHERE slug = ?""",
-            (version[0]["title"], version[0]["content_md"], new_version, slug),
+               updated_at = CURRENT_TIMESTAMP WHERE slug = ? AND version = ?""",
+            (version[0]["title"], version[0]["content_md"], new_version, slug, body.base_version),
         )
+        if cursor.rowcount == 0:
+            latest = await db.execute_fetchall(
+                "SELECT version FROM pages WHERE slug = ?", (slug,)
+            )
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "error": "conflict",
+                    "message": "This page was modified by someone else. Reload the versions list and try again.",
+                    "current_version": latest[0]["version"] if latest else None,
+                    "your_version": body.base_version,
+                },
+            )
         await rebuild_search_index(db, current["id"], version[0]["title"], version[0]["content_md"])
         await parse_and_update_backlinks(db, current["id"], version[0]["content_md"])
         await parse_and_update_media_refs(db, current["id"], version[0]["content_md"])
@@ -171,4 +190,19 @@ async def revert_to_version(
         )
 
     rows = await db.execute_fetchall("SELECT * FROM pages WHERE slug = ?", (slug,))
-    return dict(rows[0])
+    updated = dict(rows[0])
+
+    # A revert changes content like any edit, so watchers and @mentions in the
+    # reverted-to content must be notified (previously skipped).
+    await notify_page_updated(
+        db, updated, user, {"title_changed": True, "content_changed": True}
+    )
+    await notify_mentions(
+        db,
+        content_md=version[0]["content_md"],
+        page_id=current["id"],
+        actor=user,
+        old_content_md=old_content,
+    )
+
+    return updated

--- a/backend/app/services/client_ip.py
+++ b/backend/app/services/client_ip.py
@@ -3,7 +3,14 @@
 When JustWiki sits behind a reverse proxy, `request.client.host` is the
 proxy's address — all real clients collapse into a single bucket and the
 rate limiter either no-ops or denies everyone. Enabling TRUST_PROXY
-tells us to read the left-most `X-Forwarded-For` entry instead.
+tells us to read the client IP from `X-Forwarded-For` instead.
+
+Critically, we take the entry `TRUST_PROXY_HOPS` from the RIGHT, not the
+left. `X-Forwarded-For` is `client, proxy1, proxy2, …` and each hop only
+appends the address it directly saw, so the trustworthy value is the one
+your own proxy appended (rightmost). The left-most entries are supplied by
+the client and can be forged — trusting them lets an attacker rotate a
+fake IP per request to defeat the login/public rate limiters.
 
 Only enable TRUST_PROXY when a trusted proxy is actually in front of the
 app: otherwise anyone can spoof the header and dodge the limiter.
@@ -17,11 +24,15 @@ def client_ip(request: Request) -> str:
     if settings.TRUST_PROXY:
         fwd = request.headers.get("X-Forwarded-For", "")
         if fwd:
-            # X-Forwarded-For is a comma-separated chain. The left-most
-            # entry is the original client; subsequent hops are proxies.
-            first = fwd.split(",", 1)[0].strip()
-            if first:
-                return first
+            chain = [p.strip() for p in fwd.split(",") if p.strip()]
+            if chain:
+                # Take the entry `hops` from the right: index -hops. The
+                # rightmost is what our closest trusted proxy observed; going
+                # further left crosses into client-controlled territory. Clamp
+                # to the leftmost we actually have rather than over-trusting.
+                hops = max(1, settings.TRUST_PROXY_HOPS)
+                idx = max(0, len(chain) - hops)
+                return chain[idx]
         real = request.headers.get("X-Real-IP")
         if real:
             return real.strip()

--- a/backend/app/services/ldap_auth.py
+++ b/backend/app/services/ldap_auth.py
@@ -201,10 +201,15 @@ async def authenticate(username: str, password: str) -> Optional[LdapUser]:
 
 async def _load_user_by_id(db, user_id: int) -> dict:
     rows = await db.execute_fetchall(
-        "SELECT id, username, role, display_name, email FROM users WHERE id = ?",
+        "SELECT id, username, role, display_name, email, is_active FROM users WHERE id = ?",
         (user_id,),
     )
-    return dict(rows[0])
+    if not rows or not rows[0]["is_active"]:
+        # A deactivated account must not be able to sign in via LDAP either.
+        raise LdapError("User account is disabled.")
+    user = dict(rows[0])
+    user.pop("is_active", None)
+    return user
 
 
 def _admin_groups() -> set[str]:

--- a/backend/app/services/oidc.py
+++ b/backend/app/services/oidc.py
@@ -263,7 +263,8 @@ async def _pick_unique_username(db, email: str) -> str:
 
 async def _load_user_by_id(db, user_id: int) -> dict:
     rows = await db.execute_fetchall(
-        "SELECT id, username, role, display_name, email FROM users WHERE id = ? AND deleted_at IS NULL",
+        "SELECT id, username, role, display_name, email FROM users "
+        "WHERE id = ? AND deleted_at IS NULL AND is_active = 1",
         (user_id,),
     )
     if not rows:

--- a/backend/app/services/wikilink.py
+++ b/backend/app/services/wikilink.py
@@ -27,10 +27,16 @@ async def parse_and_update_backlinks(db, source_page_id: int, content_md: str):
     if not slugs:
         return
 
-    # Resolve slugs to page IDs (skip soft-deleted targets)
+    # Resolve slugs to page IDs. We deliberately DO NOT skip soft-deleted
+    # targets here: if a linked page is currently in the trash and the source
+    # page is re-saved, dropping the backlink would lose it permanently —
+    # restoring the target only rebuilds ITS outgoing links, not inbound ones.
+    # Keeping the row is safe because every read path (backlinks panel, graph)
+    # filters deleted pages, and the ON DELETE CASCADE FKs clean it up if the
+    # target is ever purged.
     placeholders = ",".join("?" for _ in slugs)
     rows = await db.execute_fetchall(
-        f"SELECT id, slug FROM pages WHERE slug IN ({placeholders}) AND deleted_at IS NULL",
+        f"SELECT id, slug FROM pages WHERE slug IN ({placeholders})",
         list(slugs),
     )
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -59,6 +59,21 @@ async def _bound_db_per_test():
             await close_db()
 
 
+@pytest.fixture(autouse=True)
+def _reset_login_rate_limit():
+    """Clear the in-memory login rate-limiter between tests.
+
+    The limiter is process-global and its 60s window never elapses within a
+    fast test run, so login attempts would otherwise accumulate across tests
+    on the shared client IP and trip a 429 in an unrelated later test.
+    """
+    from app.routers import auth_router
+
+    auth_router._login_attempts.clear()
+    yield
+    auth_router._login_attempts.clear()
+
+
 @pytest.fixture
 async def client():
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:

--- a/backend/tests/test_correctness_fixes.py
+++ b/backend/tests/test_correctness_fixes.py
@@ -1,0 +1,68 @@
+"""Regression tests for the correctness-fix pass."""
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_backlink_survives_target_trash_edit_restore(auth_client):
+    """An inbound backlink must not be lost when the target is trashed,
+    the source is re-saved, and the target is later restored."""
+    await auth_client.post("/api/pages", json={
+        "title": "Target", "content_md": "target body", "slug": "bl-target",
+    })
+    await auth_client.post("/api/pages", json={
+        "title": "Source", "content_md": "see [[bl-target]]", "slug": "bl-source",
+    })
+
+    # Backlink is present initially.
+    res = await auth_client.get("/api/pages/bl-target/backlinks")
+    assert any(b["slug"] == "bl-source" for b in res.json())
+
+    # Trash the target, then re-save the source while the target is gone.
+    await auth_client.delete("/api/pages/bl-target")
+    src = await auth_client.get("/api/pages/bl-source")
+    await auth_client.put("/api/pages/bl-source", json={
+        "content_md": "see [[bl-target]] still",
+        "base_version": src.json()["version"],
+    })
+
+    # Restore the target — the inbound backlink from source is intact.
+    restored = await auth_client.post("/api/trash/bl-target/restore")
+    assert restored.status_code in (200, 201)
+    res = await auth_client.get("/api/pages/bl-target/backlinks")
+    assert any(b["slug"] == "bl-source" for b in res.json()), \
+        "backlink from source was lost across trash/edit/restore"
+
+
+@pytest.mark.asyncio
+async def test_revert_requires_base_version(auth_client):
+    """Revert must reject a request that omits base_version (no silent fallback)."""
+    await auth_client.post("/api/pages", json={
+        "title": "Rev", "content_md": "v1", "slug": "rev-page",
+    })
+    await auth_client.put("/api/pages/rev-page", json={
+        "content_md": "v2", "base_version": 1,
+    })
+
+    # Missing base_version → 400.
+    res = await auth_client.post("/api/pages/rev-page/revert/1", json={})
+    assert res.status_code == 400
+    assert res.json()["detail"]["error"] == "base_version_required"
+
+    # Stale base_version → 409.
+    res = await auth_client.post(
+        "/api/pages/rev-page/revert/1", json={"base_version": 1}
+    )
+    assert res.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_update_rejects_nonexistent_parent(auth_client):
+    """Setting parent_id to a nonexistent page is a clean 400, not a 500."""
+    await auth_client.post("/api/pages", json={
+        "title": "Child", "content_md": "x", "slug": "parent-child",
+    })
+    cur = await auth_client.get("/api/pages/parent-child")
+    res = await auth_client.put("/api/pages/parent-child", json={
+        "parent_id": 999999, "base_version": cur.json()["version"],
+    })
+    assert res.status_code == 400

--- a/backend/tests/test_public_page.py
+++ b/backend/tests/test_public_page.py
@@ -108,10 +108,15 @@ async def test_drawio_inline(auth_client, client, db):
         "slug": "public-diag",
     })
     await auth_client.put("/api/pages/public-diag", json={"is_public": True})
+    page_rows = await db.execute_fetchall(
+        "SELECT id FROM pages WHERE slug = ?", ("public-diag",)
+    )
+    public_page_id = page_rows[0]["id"]
 
+    # Diagram owned by the public page → inlined.
     await db.execute(
-        "INSERT INTO diagrams (id, name, xml_data, svg_cache) VALUES (?, ?, ?, ?)",
-        (42, "test", "<mxfile/>", "<svg>hi</svg>"),
+        "INSERT INTO diagrams (id, name, xml_data, svg_cache, page_id) VALUES (?, ?, ?, ?, ?)",
+        (42, "test", "<mxfile/>", "<svg>hi</svg>", public_page_id),
     )
     await db.commit()
 
@@ -119,6 +124,39 @@ async def test_drawio_inline(auth_client, client, db):
     assert res.status_code == 200
     body = res.json()
     assert body["diagrams"] == {"42": "<svg>hi</svg>"}
+
+
+@pytest.mark.asyncio
+async def test_drawio_inline_rejects_private_diagram(auth_client, client, db):
+    """A public page must not exfiltrate a diagram owned by a private page."""
+    # Public page embeds a diagram id owned by a private page.
+    await auth_client.post("/api/pages", json={
+        "title": "Public Host",
+        "content_md": "before ::drawio[91] after",
+        "slug": "public-host",
+    })
+    await auth_client.put("/api/pages/public-host", json={"is_public": True})
+
+    await auth_client.post("/api/pages", json={
+        "title": "Private Owner",
+        "content_md": "owns a secret diagram",
+        "slug": "private-owner",
+    })
+    priv_rows = await db.execute_fetchall(
+        "SELECT id FROM pages WHERE slug = ?", ("private-owner",)
+    )
+    private_page_id = priv_rows[0]["id"]
+
+    await db.execute(
+        "INSERT INTO diagrams (id, name, xml_data, svg_cache, page_id) VALUES (?, ?, ?, ?, ?)",
+        (91, "secret", "<mxfile/>", "<svg>secret</svg>", private_page_id),
+    )
+    await db.commit()
+
+    res = await client.get("/api/public/pages/public-host")
+    assert res.status_code == 200
+    # The private diagram's SVG is NOT inlined.
+    assert res.json()["diagrams"] == {}
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_security_hardening.py
+++ b/backend/tests/test_security_hardening.py
@@ -49,6 +49,25 @@ async def test_upload_png_served_inline_with_explicit_type(auth_client):
 
 
 @pytest.mark.asyncio
+async def test_upload_svg_serves_as_image_with_attachment(auth_client):
+    """A clean SVG icon still renders in <img> (explicit image/svg+xml) but
+    downloads on direct navigation (attachment), so it can't run as a
+    top-level document."""
+    svg = b'<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"></svg>'
+    files = {"file": ("icon.svg", svg, "image/svg+xml")}
+    res = await auth_client.post("/api/media/upload", files=files)
+    assert res.status_code == 201
+    filename = res.json()["filename"]
+    assert filename.endswith(".svg")
+
+    got = await auth_client.get(f"/api/media/{filename}")
+    assert got.status_code == 200
+    assert got.headers["content-type"].startswith("image/svg+xml")
+    assert "attachment" in got.headers.get("content-disposition", "").lower()
+    assert got.headers.get("x-content-type-options") == "nosniff"
+
+
+@pytest.mark.asyncio
 async def test_activity_feed_hides_group_activity_from_non_admin(
     admin_client, auth_client
 ):

--- a/backend/tests/test_security_hardening.py
+++ b/backend/tests/test_security_hardening.py
@@ -1,0 +1,70 @@
+"""Regression tests for the security-hardening pass.
+
+Covers the media stored-XSS fix (extension derived from MIME, non-image
+served as a neutral attachment) and the activity-feed leak fix (group/token
+activity is admin-only).
+"""
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_upload_html_disguised_as_text_is_neutralized(auth_client):
+    """A text/plain upload named *.html must not be stored/served as HTML."""
+    files = {"file": ("evil.html", b"<script>alert(1)</script>", "text/plain")}
+    res = await auth_client.post("/api/media/upload", files=files)
+    assert res.status_code == 201
+    filename = res.json()["filename"]
+    # Stored extension comes from the validated MIME (text/plain → .txt),
+    # never from the attacker-controlled filename.
+    assert filename.endswith(".txt")
+
+    # Uploader can fetch their own orphan media; it must come back as a
+    # download with a neutral type, never text/html.
+    got = await auth_client.get(f"/api/media/{filename}")
+    assert got.status_code == 200
+    assert got.headers["content-type"].startswith("application/octet-stream")
+    assert "attachment" in got.headers.get("content-disposition", "").lower()
+    assert got.headers.get("x-content-type-options") == "nosniff"
+
+
+@pytest.mark.asyncio
+async def test_upload_png_served_inline_with_explicit_type(auth_client):
+    """Known-safe images are still served inline with an explicit type."""
+    # 1x1 transparent PNG.
+    png = bytes.fromhex(
+        "89504e470d0a1a0a0000000d494844520000000100000001080600000"
+        "01f15c4890000000d49444154789c6360000002000100" "05fe02fea7"
+        "8f0f0000000049454e44ae426082"
+    )
+    files = {"file": ("pic.png", png, "image/png")}
+    res = await auth_client.post("/api/media/upload", files=files)
+    assert res.status_code == 201
+    filename = res.json()["filename"]
+    assert filename.endswith(".png")
+
+    got = await auth_client.get(f"/api/media/{filename}")
+    assert got.status_code == 200
+    assert got.headers["content-type"].startswith("image/png")
+    assert "attachment" not in got.headers.get("content-disposition", "").lower()
+
+
+@pytest.mark.asyncio
+async def test_activity_feed_hides_group_activity_from_non_admin(
+    admin_client, auth_client
+):
+    """Group lifecycle activity must not leak to non-admin callers."""
+    created = await admin_client.post("/api/groups", json={"name": "secret-team"})
+    assert created.status_code in (200, 201)
+
+    # Non-admin editor: feed carries no group/token rows.
+    editor_feed = await auth_client.get("/api/activity")
+    assert editor_feed.status_code == 200
+    for row in editor_feed.json()["activities"]:
+        assert row["target_type"] not in ("group", "api_token")
+
+    # Admin: the group row is visible.
+    admin_feed = await admin_client.get("/api/activity")
+    assert admin_feed.status_code == 200
+    assert any(
+        row["target_type"] == "group" for row in admin_feed.json()["activities"]
+    )

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -44,6 +44,53 @@ async def test_delete_self_fails(admin_client, admin_user):
     assert response.json()["detail"] == "Cannot delete yourself"
 
 
+@pytest.mark.asyncio
+async def test_deactivate_blocks_login_and_token(admin_client, db):
+    """A deactivated user cannot log in and their session/token stops working."""
+    pw = "secretpw"
+    cursor = await db.execute(
+        "INSERT INTO users (username, password_hash, role) VALUES (?, ?, ?)",
+        ("suspendme", hash_password(pw), "editor"),
+    )
+    user_id = cursor.lastrowid
+    await db.commit()
+
+    # Login works while active.
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        ok = await c.post("/api/auth/login", json={"username": "suspendme", "password": pw})
+        assert ok.status_code == 200
+
+    # Their JWT resolves while active.
+    token = create_token(user_id, "suspendme", "editor")
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+        headers={"Authorization": f"Bearer {token}"},
+    ) as c:
+        assert (await c.get("/api/auth/me")).status_code == 200
+
+    # Deactivate.
+    res = await admin_client.put(f"/api/users/{user_id}", json={"is_active": False})
+    assert res.status_code == 200
+    assert res.json()["is_active"] == 0
+
+    # Login now fails generically, and the existing JWT no longer resolves.
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        bad = await c.post("/api/auth/login", json={"username": "suspendme", "password": pw})
+        assert bad.status_code == 401
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+        headers={"Authorization": f"Bearer {token}"},
+    ) as c:
+        assert (await c.get("/api/auth/me")).status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_cannot_deactivate_self(admin_client, admin_user):
+    user_id = admin_user["user"]["id"]
+    res = await admin_client.put(f"/api/users/{user_id}", json={"is_active": False})
+    assert res.status_code == 400
+
+
 # --- Soft-delete -----------------------------------------------------------
 
 

--- a/backend/tests/test_versions.py
+++ b/backend/tests/test_versions.py
@@ -28,8 +28,10 @@ async def test_versions(auth_client):
     assert response.status_code == 200
     assert response.json()["title"] == "Version Page"
 
-    # Restore version
-    response = await auth_client.post(f"/api/pages/version-page/revert/{version_num}")
+    # Restore version — base_version is required (page is at v2 after the edit).
+    response = await auth_client.post(
+        f"/api/pages/version-page/revert/{version_num}", json={"base_version": 2}
+    )
     assert response.status_code == 200
     assert response.json()["title"] == "Version Page"
 

--- a/frontend/src/components/Comments.jsx
+++ b/frontend/src/components/Comments.jsx
@@ -16,8 +16,9 @@ function CommentItem({ comment, currentUser, onDelete, onUpdate, pageSlug }) {
 
   const handleSave = async () => {
     if (!editContent.trim()) return
-    await onUpdate(comment.id, editContent.trim())
-    setEditing(false)
+    // Keep edit mode open if the update failed so the edit isn't lost.
+    const ok = await onUpdate(comment.id, editContent.trim())
+    if (ok !== false) setEditing(false)
   }
 
   return (
@@ -87,6 +88,7 @@ export default function Comments({ slug }) {
   const [loadedSlug, setLoadedSlug] = useState(slug)
   const [newComment, setNewComment] = useState('')
   const [submitting, setSubmitting] = useState(false)
+  const [actionError, setActionError] = useState('')
 
   // Reset loading when the slug changes (adjusting state during render).
   if (loadedSlug !== slug) {
@@ -119,27 +121,39 @@ export default function Comments({ slug }) {
     e.preventDefault()
     if (!newComment.trim() || submitting) return
     setSubmitting(true)
+    setActionError('')
     try {
       await api.post(`/pages/${slug}/comments`, { content: newComment.trim() })
       setNewComment('')
       loadComments()
-    } catch { /* ignore */ }
+    } catch {
+      // Keep the draft in the textarea so the user doesn't lose it.
+      setActionError(t('comments.postFailed'))
+    }
     setSubmitting(false)
   }
 
   const handleDelete = async (commentId) => {
     if (!confirm(t('comments.confirmDelete'))) return
+    setActionError('')
     try {
       await api.delete(`/pages/${slug}/comments/${commentId}`)
       loadComments()
-    } catch { /* ignore */ }
+    } catch {
+      setActionError(t('comments.deleteFailed'))
+    }
   }
 
   const handleUpdate = async (commentId, content) => {
+    setActionError('')
     try {
       await api.put(`/pages/${slug}/comments/${commentId}`, { content })
       loadComments()
-    } catch { /* ignore */ }
+      return true
+    } catch {
+      setActionError(t('comments.updateFailed'))
+      return false
+    }
   }
 
   return (
@@ -164,6 +178,12 @@ export default function Comments({ slug }) {
                   pageSlug={slug}
                 />
               ))}
+            </div>
+          )}
+
+          {actionError && (
+            <div className="mb-3 text-sm text-red-600 dark:text-red-400" role="alert">
+              {actionError}
             </div>
           )}
 

--- a/frontend/src/hooks/useUnsavedWarning.jsx
+++ b/frontend/src/hooks/useUnsavedWarning.jsx
@@ -1,13 +1,93 @@
 import { useEffect } from 'react'
 
-export default function useUnsavedWarning(isDirty) {
+/**
+ * Warn before losing unsaved edits.
+ *
+ * Two layers, because the app uses <BrowserRouter> (not a data router), so
+ * React Router's useBlocker is unavailable:
+ *   1. `beforeunload` — covers full-page unloads (refresh, tab close, typing a
+ *      new URL, external links).
+ *   2. A capture-phase click guard on in-app <a> navigation — covers SPA
+ *      links (sidebar tree, wikilinks, the nav logo, bookmarks). Firing in the
+ *      capture phase on `document` lets us preventDefault + stopPropagation
+ *      before React Router's <Link> onClick runs, so a cancelled confirm keeps
+ *      the user on the page.
+ *
+ * Button-driven navigations inside a component (e.g. a Cancel button that
+ * calls navigate()) aren't <a> clicks — guard those at the call site with
+ * confirmDiscard() below.
+ *
+ * @param {boolean} isDirty  whether there are unsaved changes
+ * @param {string}  message  confirmation prompt shown before discarding
+ */
+export default function useUnsavedWarning(isDirty, message) {
   useEffect(() => {
     if (!isDirty) return
-    const handler = (e) => {
+
+    const onBeforeUnload = (e) => {
       e.preventDefault()
       e.returnValue = ''
     }
-    window.addEventListener('beforeunload', handler)
-    return () => window.removeEventListener('beforeunload', handler)
-  }, [isDirty])
+
+    const onClickCapture = (e) => {
+      // Let modified clicks (new tab/window), non-left buttons, and already
+      // handled events through untouched.
+      if (
+        e.defaultPrevented ||
+        e.button !== 0 ||
+        e.metaKey ||
+        e.ctrlKey ||
+        e.shiftKey ||
+        e.altKey
+      ) {
+        return
+      }
+      // Ignore clicks inside the editor (contenteditable): links there don't
+      // navigate via the router — clicking one just places the cursor — so a
+      // confirm there would be a false positive.
+      if (e.target.closest?.('[contenteditable="true"], [contenteditable=""]')) {
+        return
+      }
+      const anchor = e.target.closest?.('a[href]')
+      if (!anchor) return
+      const targetAttr = anchor.getAttribute('target')
+      if ((targetAttr && targetAttr !== '_self') || anchor.hasAttribute('download')) {
+        return
+      }
+      const href = anchor.getAttribute('href')
+      if (!href || href.startsWith('#')) return
+
+      let url
+      try {
+        url = new URL(anchor.href, window.location.href)
+      } catch {
+        return
+      }
+      // External links unload the page → beforeunload handles those.
+      if (url.origin !== window.location.origin) return
+      // No navigation if it points at the current location.
+      if (url.pathname === window.location.pathname && url.search === window.location.search) {
+        return
+      }
+      if (!window.confirm(message)) {
+        e.preventDefault()
+        e.stopPropagation()
+      }
+    }
+
+    window.addEventListener('beforeunload', onBeforeUnload)
+    document.addEventListener('click', onClickCapture, true)
+    return () => {
+      window.removeEventListener('beforeunload', onBeforeUnload)
+      document.removeEventListener('click', onClickCapture, true)
+    }
+  }, [isDirty, message])
+}
+
+/**
+ * Imperative confirm for button-driven navigation (Cancel, etc.). Returns
+ * true if it's safe to proceed (not dirty, or the user accepted the prompt).
+ */
+export function confirmDiscard(isDirty, message) {
+  return !isDirty || window.confirm(message)
 }

--- a/frontend/src/i18n.js
+++ b/frontend/src/i18n.js
@@ -6,6 +6,7 @@ import en from './locales/en.json'
 import zhTW from './locales/zh-TW.json'
 import ja from './locales/ja.json'
 import ko from './locales/ko.json'
+import { setCalloutTitles } from './lib/calloutTitles'
 
 export const SUPPORTED_LANGUAGES = [
   { code: 'en', label: 'English' },
@@ -48,5 +49,19 @@ i18n
       convertDetectedLanguage: normalizeLang,
     },
   })
+
+// Keep the shared markdown callout headers in sync with the active language.
+// The markdown pipeline is synchronous and shared by both render paths, so it
+// reads these from a mutable module instead of calling t() directly.
+function syncCalloutTitles() {
+  setCalloutTitles({
+    info: i18n.t('callout.info'),
+    warning: i18n.t('callout.warning'),
+    tip: i18n.t('callout.tip'),
+    danger: i18n.t('callout.danger'),
+  })
+}
+syncCalloutTitles()
+i18n.on('languageChanged', syncCalloutTitles)
 
 export default i18n

--- a/frontend/src/lib/calloutTitles.js
+++ b/frontend/src/lib/calloutTitles.js
@@ -1,0 +1,14 @@
+// Callout header labels shared by both markdown render paths (the markdown-it
+// pipeline in lib/markdown.js and the v2 remark/rehype pipeline in
+// lib/markdown/render-v2.js).
+//
+// Kept as a single mutable object so i18n can localize the headers without
+// threading a `t()` function through the shared, synchronous markdown
+// pipeline. i18n.js calls setCalloutTitles() on init and on every language
+// change; both pipelines read this object at render time, so the next render
+// picks up the current language. Defaults to English.
+export const CALLOUT_TITLES = { info: 'Info', warning: 'Warning', tip: 'Tip', danger: 'Danger' }
+
+export function setCalloutTitles(map) {
+  if (map) Object.assign(CALLOUT_TITLES, map)
+}

--- a/frontend/src/lib/markdown.js
+++ b/frontend/src/lib/markdown.js
@@ -20,14 +20,14 @@ import MarkdownIt from 'markdown-it'
 import container from 'markdown-it-container'
 import katex from 'katex'
 
+import { CALLOUT_TITLES } from './calloutTitles'
+
 const CALLOUT_ICONS = {
   info: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>',
   warning: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>',
   tip: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18h6"/><path d="M10 22h4"/><path d="M12 2a7 7 0 00-4 12.7V17h8v-2.3A7 7 0 0012 2z"/></svg>',
   danger: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="7.86 2 16.14 2 22 7.86 22 16.14 16.14 22 7.86 22 2 16.14 2 7.86 7.86 2"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg>',
 }
-const CALLOUT_TITLES = { info: 'Info', warning: 'Warning', tip: 'Tip', danger: 'Danger' }
-
 function renderKatex(tex, displayMode) {
   try {
     return katex.renderToString(tex, { displayMode, throwOnError: false })

--- a/frontend/src/lib/markdown/render-v2.js
+++ b/frontend/src/lib/markdown/render-v2.js
@@ -61,9 +61,9 @@ import { visit } from 'unist-util-visit'
 
 import { remarkWikilinkPlugin } from './plugins/wikilink'
 import { remarkMentionPlugin } from './plugins/mention'
+import { CALLOUT_TITLES } from '../calloutTitles'
 
 const CALLOUT_TYPES = new Set(['info', 'warning', 'tip', 'danger'])
-const CALLOUT_TITLES = { info: 'Info', warning: 'Warning', tip: 'Tip', danger: 'Danger' }
 
 // Inline SVGs kept identical to the v1 renderer's output so styling stays
 // pixel-stable when toggling the flag.

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1,4 +1,10 @@
 {
+  "callout": {
+    "info": "Info",
+    "warning": "Warning",
+    "tip": "Tip",
+    "danger": "Danger"
+  },
   "common": {
     "loading": "Loading...",
     "loadingGraph": "Loading graph…",
@@ -84,7 +90,10 @@
     "post": "Comment",
     "posting": "Posting...",
     "confirmDelete": "Delete this comment?",
-    "signInToReply": "Sign in to join the discussion."
+    "signInToReply": "Sign in to join the discussion.",
+    "postFailed": "Could not post your comment. Please try again.",
+    "deleteFailed": "Could not delete the comment. Please try again.",
+    "updateFailed": "Could not save your edit. Please try again."
   },
   "acl": {
     "title": "Manage permissions",
@@ -180,6 +189,35 @@
       "intro": "Export the entire wiki as a static HTML website.",
       "btn": "Export Static Site (.zip)"
     },
+    "webhooks": {
+      "title": "Webhooks",
+      "intro": "POST a JSON payload to an external URL when pages are created, updated, or deleted.",
+      "add": "+ Add Webhook",
+      "namePlaceholder": "Name (e.g. Slack notifier)",
+      "urlPlaceholder": "https://example.com/hook",
+      "create": "Create",
+      "cancel": "Cancel",
+      "validation": "Name, URL, and at least one event are required.",
+      "createFailed": "Failed to create webhook",
+      "updateFailed": "Failed to update webhook",
+      "deleteFailed": "Failed to delete webhook",
+      "confirmDelete": "Delete webhook \"{{name}}\"?",
+      "empty": "No webhooks configured.",
+      "enable": "Enable",
+      "disable": "Disable",
+      "delete": "Delete",
+      "status": {
+        "active": "Active",
+        "disabled": "Disabled"
+      },
+      "col": {
+        "name": "Name",
+        "url": "URL",
+        "events": "Events",
+        "status": "Status",
+        "actions": "Actions"
+      }
+    },
     "users": {
       "title": "Users",
       "tabActive": "Active",
@@ -199,12 +237,21 @@
       "col": {
         "username": "Username",
         "role": "Role",
+        "status": "Status",
         "created": "Created",
         "actions": "Actions",
         "originalUsername": "Original username",
         "displayName": "Display name",
         "deleted": "Deleted"
       },
+      "status": {
+        "active": "Active",
+        "suspended": "Suspended"
+      },
+      "activate": "Activate",
+      "deactivate": "Deactivate",
+      "confirmDeactivate": "Deactivate \"{{username}}\"? They will be signed out and unable to log in until reactivated. Their pages and history are kept.",
+      "statusUpdateFailed": "Failed to update status",
       "delete": "Delete",
       "confirmDelete": "Delete user \"{{username}}\"?\n\nThis is a soft-delete — the account is deactivated, the username \"{{username}}\" is freed for reuse, and pages they authored keep their authorship. You can restore the account from the Deleted tab.",
       "deleteFailed": "Failed to delete user",
@@ -452,6 +499,7 @@
     "save": "Save",
     "saving": "Saving...",
     "saveFailed": "Save failed",
+    "unsavedWarning": "You have unsaved changes. Leave without saving?",
     "conflict": {
       "title": "⚠ Edit conflict",
       "default": "This page was modified by someone else.",

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -1,4 +1,10 @@
 {
+  "callout": {
+    "info": "情報",
+    "warning": "警告",
+    "tip": "ヒント",
+    "danger": "危険"
+  },
   "common": {
     "loading": "読み込み中…",
     "loadingGraph": "グラフを読み込み中…",
@@ -84,7 +90,10 @@
     "post": "投稿",
     "posting": "投稿中…",
     "confirmDelete": "このコメントを削除しますか？",
-    "signInToReply": "ログインしてディスカッションに参加してください。"
+    "signInToReply": "ログインしてディスカッションに参加してください。",
+    "postFailed": "コメントを投稿できませんでした。もう一度お試しください。",
+    "deleteFailed": "コメントを削除できませんでした。もう一度お試しください。",
+    "updateFailed": "編集を保存できませんでした。もう一度お試しください。"
   },
   "acl": {
     "title": "権限を管理",
@@ -180,6 +189,35 @@
       "intro": "Wiki 全体を静的 HTML サイトとして書き出します。",
       "btn": "静的サイトをエクスポート (.zip)"
     },
+    "webhooks": {
+      "title": "Webhook",
+      "intro": "ページの作成・更新・削除時に、外部 URL へ JSON ペイロードを POST します。",
+      "add": "+ Webhook を追加",
+      "namePlaceholder": "名前（例: Slack 通知）",
+      "urlPlaceholder": "https://example.com/hook",
+      "create": "作成",
+      "cancel": "キャンセル",
+      "validation": "名前・URL・少なくとも 1 つのイベントが必要です。",
+      "createFailed": "Webhook の作成に失敗しました",
+      "updateFailed": "Webhook の更新に失敗しました",
+      "deleteFailed": "Webhook の削除に失敗しました",
+      "confirmDelete": "Webhook「{{name}}」を削除しますか？",
+      "empty": "Webhook は設定されていません。",
+      "enable": "有効化",
+      "disable": "無効化",
+      "delete": "削除",
+      "status": {
+        "active": "有効",
+        "disabled": "無効"
+      },
+      "col": {
+        "name": "名前",
+        "url": "URL",
+        "events": "イベント",
+        "status": "ステータス",
+        "actions": "操作"
+      }
+    },
     "users": {
       "title": "ユーザー",
       "tabActive": "有効",
@@ -199,12 +237,21 @@
       "col": {
         "username": "ユーザー名",
         "role": "ロール",
+        "status": "ステータス",
         "created": "作成日",
         "actions": "操作",
         "originalUsername": "元ユーザー名",
         "displayName": "表示名",
         "deleted": "削除日"
       },
+      "status": {
+        "active": "有効",
+        "suspended": "停止中"
+      },
+      "activate": "有効化",
+      "deactivate": "無効化",
+      "confirmDeactivate": "「{{username}}」を無効化しますか？サインアウトされ、再有効化するまでログインできなくなります。ページと履歴は保持されます。",
+      "statusUpdateFailed": "ステータスの更新に失敗しました",
       "delete": "削除",
       "confirmDelete": "ユーザー「{{username}}」を削除しますか？\n\nこれはソフト削除です。アカウントは無効化され、ユーザー名「{{username}}」は再利用可能になります。作成済みのページは作者情報を保持します。「削除済み」タブから復元できます。",
       "deleteFailed": "ユーザーの削除に失敗しました",
@@ -452,6 +499,7 @@
     "save": "保存",
     "saving": "保存中…",
     "saveFailed": "保存に失敗しました",
+    "unsavedWarning": "保存していない変更があります。保存せずに移動しますか？",
     "conflict": {
       "title": "⚠ 編集競合",
       "default": "このページは他のユーザーによって変更されました。",

--- a/frontend/src/locales/ko.json
+++ b/frontend/src/locales/ko.json
@@ -1,4 +1,10 @@
 {
+  "callout": {
+    "info": "정보",
+    "warning": "경고",
+    "tip": "팁",
+    "danger": "위험"
+  },
   "common": {
     "loading": "불러오는 중…",
     "loadingGraph": "그래프 불러오는 중…",
@@ -84,7 +90,10 @@
     "post": "댓글 등록",
     "posting": "등록 중…",
     "confirmDelete": "이 댓글을 삭제할까요?",
-    "signInToReply": "로그인하여 토론에 참여하세요."
+    "signInToReply": "로그인하여 토론에 참여하세요.",
+    "postFailed": "댓글을 게시하지 못했습니다. 다시 시도해 주세요.",
+    "deleteFailed": "댓글을 삭제하지 못했습니다. 다시 시도해 주세요.",
+    "updateFailed": "수정 내용을 저장하지 못했습니다. 다시 시도해 주세요."
   },
   "acl": {
     "title": "권한 관리",
@@ -180,6 +189,35 @@
       "intro": "위키 전체를 정적 HTML 사이트로 내보냅니다.",
       "btn": "정적 사이트 내보내기 (.zip)"
     },
+    "webhooks": {
+      "title": "웹훅",
+      "intro": "페이지가 생성·수정·삭제될 때 외부 URL로 JSON 페이로드를 POST합니다.",
+      "add": "+ 웹훅 추가",
+      "namePlaceholder": "이름 (예: Slack 알림)",
+      "urlPlaceholder": "https://example.com/hook",
+      "create": "생성",
+      "cancel": "취소",
+      "validation": "이름, URL, 하나 이상의 이벤트가 필요합니다.",
+      "createFailed": "웹훅 생성에 실패했습니다",
+      "updateFailed": "웹훅 업데이트에 실패했습니다",
+      "deleteFailed": "웹훅 삭제에 실패했습니다",
+      "confirmDelete": "웹훅 \"{{name}}\"을(를) 삭제할까요?",
+      "empty": "구성된 웹훅이 없습니다.",
+      "enable": "활성화",
+      "disable": "비활성화",
+      "delete": "삭제",
+      "status": {
+        "active": "활성",
+        "disabled": "비활성"
+      },
+      "col": {
+        "name": "이름",
+        "url": "URL",
+        "events": "이벤트",
+        "status": "상태",
+        "actions": "작업"
+      }
+    },
     "users": {
       "title": "사용자",
       "tabActive": "활성",
@@ -199,12 +237,21 @@
       "col": {
         "username": "사용자명",
         "role": "역할",
+        "status": "상태",
         "created": "생성일",
         "actions": "작업",
         "originalUsername": "원래 사용자명",
         "displayName": "표시 이름",
         "deleted": "삭제 시각"
       },
+      "status": {
+        "active": "활성",
+        "suspended": "정지됨"
+      },
+      "activate": "활성화",
+      "deactivate": "비활성화",
+      "confirmDeactivate": "\"{{username}}\"을(를) 비활성화할까요? 로그아웃되며 다시 활성화하기 전까지 로그인할 수 없습니다. 페이지와 기록은 유지됩니다.",
+      "statusUpdateFailed": "상태 업데이트에 실패했습니다",
       "delete": "삭제",
       "confirmDelete": "사용자 \"{{username}}\"을(를) 삭제할까요?\n\n소프트 삭제입니다 — 계정이 비활성화되고, 사용자명 \"{{username}}\"은 다시 사용할 수 있게 풀리며, 작성한 페이지는 작성자 정보를 유지합니다. 삭제됨 탭에서 복원할 수 있습니다.",
       "deleteFailed": "사용자 삭제에 실패했습니다",
@@ -452,6 +499,7 @@
     "save": "저장",
     "saving": "저장 중…",
     "saveFailed": "저장에 실패했습니다",
+    "unsavedWarning": "저장하지 않은 변경 사항이 있습니다. 저장하지 않고 나가시겠습니까?",
     "conflict": {
       "title": "⚠ 편집 충돌",
       "default": "이 페이지가 다른 사용자에 의해 수정되었습니다.",

--- a/frontend/src/locales/zh-TW.json
+++ b/frontend/src/locales/zh-TW.json
@@ -1,4 +1,10 @@
 {
+  "callout": {
+    "info": "資訊",
+    "warning": "警告",
+    "tip": "提示",
+    "danger": "危險"
+  },
   "common": {
     "loading": "載入中…",
     "loadingGraph": "載入圖譜…",
@@ -84,7 +90,10 @@
     "post": "送出",
     "posting": "送出中…",
     "confirmDelete": "確定要刪除此留言？",
-    "signInToReply": "登入即可參與討論。"
+    "signInToReply": "登入即可參與討論。",
+    "postFailed": "留言送出失敗，請再試一次。",
+    "deleteFailed": "刪除留言失敗，請再試一次。",
+    "updateFailed": "儲存編輯失敗，請再試一次。"
   },
   "acl": {
     "title": "管理權限",
@@ -180,6 +189,35 @@
       "intro": "將整個 Wiki 匯出為靜態 HTML 網站。",
       "btn": "匯出靜態網站 (.zip)"
     },
+    "webhooks": {
+      "title": "Webhook",
+      "intro": "在頁面建立、更新或刪除時，向外部網址 POST 一則 JSON 通知。",
+      "add": "+ 新增 Webhook",
+      "namePlaceholder": "名稱（例如 Slack 通知）",
+      "urlPlaceholder": "https://example.com/hook",
+      "create": "建立",
+      "cancel": "取消",
+      "validation": "名稱、網址與至少一個事件為必填。",
+      "createFailed": "建立 Webhook 失敗",
+      "updateFailed": "更新 Webhook 失敗",
+      "deleteFailed": "刪除 Webhook 失敗",
+      "confirmDelete": "確定要刪除 Webhook「{{name}}」？",
+      "empty": "尚未設定任何 Webhook。",
+      "enable": "啟用",
+      "disable": "停用",
+      "delete": "刪除",
+      "status": {
+        "active": "啟用中",
+        "disabled": "已停用"
+      },
+      "col": {
+        "name": "名稱",
+        "url": "網址",
+        "events": "事件",
+        "status": "狀態",
+        "actions": "操作"
+      }
+    },
     "users": {
       "title": "使用者",
       "tabActive": "啟用中",
@@ -199,12 +237,21 @@
       "col": {
         "username": "使用者名稱",
         "role": "角色",
+        "status": "狀態",
         "created": "建立時間",
         "actions": "操作",
         "originalUsername": "原使用者名稱",
         "displayName": "顯示名稱",
         "deleted": "刪除時間"
       },
+      "status": {
+        "active": "啟用中",
+        "suspended": "已停用"
+      },
+      "activate": "啟用",
+      "deactivate": "停用",
+      "confirmDeactivate": "要停用「{{username}}」嗎？該使用者會被登出，且在重新啟用前無法登入。他們的頁面與歷史紀錄會保留。",
+      "statusUpdateFailed": "更新狀態失敗",
       "delete": "刪除",
       "confirmDelete": "刪除使用者「{{username}}」？\n\n這是軟刪除 — 帳號會被停用，使用者名稱「{{username}}」會被釋出供日後重用，他們建立的頁面仍保留作者資訊。可從「已刪除」分頁還原。",
       "deleteFailed": "刪除使用者失敗",
@@ -452,6 +499,7 @@
     "save": "儲存",
     "saving": "儲存中…",
     "saveFailed": "儲存失敗",
+    "unsavedWarning": "你有尚未儲存的變更，確定要離開嗎？",
     "conflict": {
       "title": "⚠ 編輯衝突",
       "default": "此頁面已被他人修改。",

--- a/frontend/src/pages/Admin.jsx
+++ b/frontend/src/pages/Admin.jsx
@@ -217,6 +217,190 @@ function ExportSection() {
   )
 }
 
+const WEBHOOK_EVENTS = ['page.created', 'page.updated', 'page.deleted']
+const DEFAULT_WEBHOOK_FORM = {
+  name: '',
+  url: '',
+  events: [...WEBHOOK_EVENTS],
+  is_active: true,
+}
+
+function WebhooksSection() {
+  const { t } = useTranslation()
+  const [hooks, setHooks] = useState([])
+  const [showForm, setShowForm] = useState(false)
+  const [form, setForm] = useState(DEFAULT_WEBHOOK_FORM)
+  const [error, setError] = useState('')
+
+  const load = async () => {
+    try {
+      const res = await api.get('/webhooks')
+      setHooks(Array.isArray(res.data) ? res.data : [])
+    } catch { /* ignore */ }
+  }
+
+  useEffect(() => {
+    let cancelled = false
+    api.get('/webhooks')
+      .then((res) => { if (!cancelled) setHooks(Array.isArray(res.data) ? res.data : []) })
+      .catch(() => { /* ignore */ })
+    return () => { cancelled = true }
+  }, [])
+
+  const resetForm = () => {
+    setForm(DEFAULT_WEBHOOK_FORM)
+    setShowForm(false)
+    setError('')
+  }
+
+  const toggleEvent = (ev) => {
+    setForm((f) => ({
+      ...f,
+      events: f.events.includes(ev)
+        ? f.events.filter((e) => e !== ev)
+        : [...f.events, ev],
+    }))
+  }
+
+  const handleCreate = async (e) => {
+    e.preventDefault()
+    setError('')
+    if (!form.name.trim() || !form.url.trim() || form.events.length === 0) {
+      setError(t('admin.webhooks.validation'))
+      return
+    }
+    try {
+      await api.post('/webhooks', {
+        name: form.name.trim(),
+        url: form.url.trim(),
+        events: form.events.join(','),
+        is_active: form.is_active,
+      })
+      resetForm()
+      load()
+    } catch (err) {
+      setError(err?.response?.data?.detail || t('admin.webhooks.createFailed'))
+    }
+  }
+
+  const handleToggleActive = async (h) => {
+    try {
+      await api.put(`/webhooks/${h.id}`, { is_active: !(h.is_active === 1 || h.is_active === true) })
+      load()
+    } catch (err) {
+      alert(err?.response?.data?.detail || t('admin.webhooks.updateFailed'))
+    }
+  }
+
+  const handleDelete = async (h) => {
+    if (!confirm(t('admin.webhooks.confirmDelete', { name: h.name }))) return
+    try {
+      await api.delete(`/webhooks/${h.id}`)
+      load()
+    } catch (err) {
+      alert(err?.response?.data?.detail || t('admin.webhooks.deleteFailed'))
+    }
+  }
+
+  return (
+    <div className="bg-surface rounded-xl shadow-sm border border-border p-6">
+      <div className="flex items-center justify-between mb-2">
+        <h2 className="text-lg font-semibold text-text">{t('admin.webhooks.title')}</h2>
+        <button
+          onClick={() => setShowForm((s) => !s)}
+          className="px-3 py-1.5 bg-primary text-primary-text rounded-lg text-sm hover:bg-primary-hover"
+        >
+          {t('admin.webhooks.add')}
+        </button>
+      </div>
+      <p className="text-sm text-text-secondary mb-4">{t('admin.webhooks.intro')}</p>
+
+      {showForm && (
+        <form onSubmit={handleCreate} className="mb-4 p-4 border border-border rounded-lg space-y-3">
+          <input
+            type="text"
+            value={form.name}
+            onChange={(e) => setForm({ ...form, name: e.target.value })}
+            placeholder={t('admin.webhooks.namePlaceholder')}
+            className="w-full px-3 py-2 border border-border rounded-lg text-sm bg-surface text-text"
+          />
+          <input
+            type="url"
+            value={form.url}
+            onChange={(e) => setForm({ ...form, url: e.target.value })}
+            placeholder={t('admin.webhooks.urlPlaceholder')}
+            className="w-full px-3 py-2 border border-border rounded-lg text-sm bg-surface text-text"
+          />
+          <div className="flex flex-wrap gap-3">
+            {WEBHOOK_EVENTS.map((ev) => (
+              <label key={ev} className="flex items-center gap-1.5 text-sm text-text">
+                <input
+                  type="checkbox"
+                  checked={form.events.includes(ev)}
+                  onChange={() => toggleEvent(ev)}
+                />
+                {ev}
+              </label>
+            ))}
+          </div>
+          {error && <div className="text-sm text-red-500" role="alert">{error}</div>}
+          <div className="flex gap-2">
+            <button type="submit" className="px-4 py-2 bg-primary text-primary-text rounded-lg text-sm hover:bg-primary-hover">
+              {t('admin.webhooks.create')}
+            </button>
+            <button type="button" onClick={resetForm} className="px-4 py-2 text-text-secondary rounded-lg text-sm hover:bg-surface-hover">
+              {t('admin.webhooks.cancel')}
+            </button>
+          </div>
+        </form>
+      )}
+
+      {hooks.length === 0 ? (
+        <div className="text-center py-6 text-text-secondary text-sm">{t('admin.webhooks.empty')}</div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border">
+                <th className="text-left py-2 px-3 text-text-secondary font-medium">{t('admin.webhooks.col.name')}</th>
+                <th className="text-left py-2 px-3 text-text-secondary font-medium">{t('admin.webhooks.col.url')}</th>
+                <th className="text-left py-2 px-3 text-text-secondary font-medium">{t('admin.webhooks.col.events')}</th>
+                <th className="text-left py-2 px-3 text-text-secondary font-medium">{t('admin.webhooks.col.status')}</th>
+                <th className="text-right py-2 px-3 text-text-secondary font-medium">{t('admin.webhooks.col.actions')}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {hooks.map((h) => {
+                const active = h.is_active === 1 || h.is_active === true
+                return (
+                  <tr key={h.id} className="border-b border-border">
+                    <td className="py-2 px-3 text-text">{h.name}</td>
+                    <td className="py-2 px-3 text-text-secondary max-w-[16rem] truncate" title={h.url}>{h.url}</td>
+                    <td className="py-2 px-3 text-text-secondary">{h.events}</td>
+                    <td className="py-2 px-3">
+                      <span className={`text-xs px-2 py-0.5 rounded-full ${active ? 'bg-green-500/10 text-green-600 dark:text-green-400' : 'bg-red-500/10 text-red-600 dark:text-red-400'}`}>
+                        {active ? t('admin.webhooks.status.active') : t('admin.webhooks.status.disabled')}
+                      </span>
+                    </td>
+                    <td className="py-2 px-3 text-right whitespace-nowrap">
+                      <button onClick={() => handleToggleActive(h)} className="text-text-secondary hover:text-text text-sm mr-3">
+                        {active ? t('admin.webhooks.disable') : t('admin.webhooks.enable')}
+                      </button>
+                      <button onClick={() => handleDelete(h)} className="text-red-500 hover:text-red-700 text-sm">
+                        {t('admin.webhooks.delete')}
+                      </button>
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}
+
 function UsersSection() {
   const { t } = useTranslation()
   const [tab, setTab] = useState('active')
@@ -301,6 +485,22 @@ function UsersSection() {
       loadUsers()
     } catch (err) {
       alert(err?.response?.data?.detail || t('admin.users.roleUpdateFailed'))
+    }
+  }
+
+  const handleToggleActive = async (u) => {
+    const nextActive = u.is_active === 0 || u.is_active === false
+    if (
+      !nextActive &&
+      !confirm(t('admin.users.confirmDeactivate', { username: u.username }))
+    ) {
+      return
+    }
+    try {
+      await api.put(`/users/${u.id}`, { is_active: nextActive })
+      loadUsers()
+    } catch (err) {
+      alert(err?.response?.data?.detail || t('admin.users.statusUpdateFailed'))
     }
   }
 
@@ -455,12 +655,15 @@ function UsersSection() {
               <tr className="border-b border-border">
                 <th className="text-left py-2 px-3 text-text-secondary font-medium">{t('admin.users.col.username')}</th>
                 <th className="text-left py-2 px-3 text-text-secondary font-medium">{t('admin.users.col.role')}</th>
+                <th className="text-left py-2 px-3 text-text-secondary font-medium">{t('admin.users.col.status')}</th>
                 <th className="text-left py-2 px-3 text-text-secondary font-medium">{t('admin.users.col.created')}</th>
                 <th className="text-right py-2 px-3 text-text-secondary font-medium">{t('admin.users.col.actions')}</th>
               </tr>
             </thead>
             <tbody>
-              {users.map((u) => (
+              {users.map((u) => {
+                const inactive = u.is_active === 0 || u.is_active === false
+                return (
                 <tr key={u.id} className="border-b border-border">
                   <td className="py-2 px-3 text-text">
                     <Link
@@ -481,14 +684,32 @@ function UsersSection() {
                       <option value="admin">{t('admin.users.role.admin')}</option>
                     </select>
                   </td>
+                  <td className="py-2 px-3">
+                    {inactive ? (
+                      <span className="text-xs px-2 py-0.5 rounded-full bg-red-500/10 text-red-600 dark:text-red-400">
+                        {t('admin.users.status.suspended')}
+                      </span>
+                    ) : (
+                      <span className="text-xs px-2 py-0.5 rounded-full bg-green-500/10 text-green-600 dark:text-green-400">
+                        {t('admin.users.status.active')}
+                      </span>
+                    )}
+                  </td>
                   <td className="py-2 px-3 text-text-secondary">{u.created_at ? new Date(u.created_at).toLocaleDateString() : '-'}</td>
-                  <td className="py-2 px-3 text-right">
+                  <td className="py-2 px-3 text-right whitespace-nowrap">
+                    <button
+                      onClick={() => handleToggleActive(u)}
+                      className="text-text-secondary hover:text-text text-sm mr-3"
+                    >
+                      {inactive ? t('admin.users.activate') : t('admin.users.deactivate')}
+                    </button>
                     <button onClick={() => handleDelete(u)} className="text-red-500 hover:text-red-700 text-sm">
                       {t('admin.users.delete')}
                     </button>
                   </td>
                 </tr>
-              ))}
+                )
+              })}
             </tbody>
           </table>
         </div>
@@ -1389,6 +1610,7 @@ export default function Admin() {
       <GroupsSection />
       <TemplatesSection />
       <LibrarySection />
+      <WebhooksSection />
       <BackupSection />
       <ExportSection />
     </div>

--- a/frontend/src/pages/NewPage.jsx
+++ b/frontend/src/pages/NewPage.jsx
@@ -7,7 +7,7 @@ import api from '../api/client'
 import Editor from '../components/Editor/Editor'
 import MediaPickerModal from '../components/Editor/MediaPickerModal'
 import DrawioModal from '../components/DrawioModal'
-import useUnsavedWarning from '../hooks/useUnsavedWarning'
+import useUnsavedWarning, { confirmDiscard } from '../hooks/useUnsavedWarning'
 import { stripBrTags } from '../lib/markdown'
 import { MINDMAP_TEMPLATE } from '../lib/mindmap'
 
@@ -97,7 +97,13 @@ export default function NewPage() {
     setDrawioOpen(false)
   }, [])
 
-  useUnsavedWarning(dirty)
+  useUnsavedWarning(dirty, t('pageEdit.unsavedWarning'))
+
+  const handleCancel = useCallback(() => {
+    if (confirmDiscard(dirty, t('pageEdit.unsavedWarning'))) {
+      navigate('/')
+    }
+  }, [dirty, t, navigate])
 
   useEffect(() => {
     api.get('/templates').then((res) => setTemplates(res.data))
@@ -286,7 +292,7 @@ export default function NewPage() {
         />
         <div className="flex gap-2">
           <button
-            onClick={() => navigate('/')}
+            onClick={handleCancel}
             className="px-3 py-1.5 text-sm text-text-secondary rounded-lg hover:bg-surface-hover"
           >
             {t('newPage.cancel')}

--- a/frontend/src/pages/PageEdit.jsx
+++ b/frontend/src/pages/PageEdit.jsx
@@ -11,7 +11,7 @@ import MarkdownViewer from '../components/Viewer/MarkdownViewer'
 import MindmapView from '../components/MindmapView'
 import MindmapLayoutSelect from '../components/MindmapLayoutSelect'
 import DrawioModal from '../components/DrawioModal'
-import useUnsavedWarning from '../hooks/useUnsavedWarning'
+import useUnsavedWarning, { confirmDiscard } from '../hooks/useUnsavedWarning'
 import { stripBrTags } from '../lib/markdown'
 import api from '../api/client'
 
@@ -62,7 +62,13 @@ export default function PageEdit() {
     }
   }, [])
 
-  useUnsavedWarning(dirty)
+  useUnsavedWarning(dirty, t('pageEdit.unsavedWarning'))
+
+  const handleCancel = useCallback(() => {
+    if (confirmDiscard(dirty, t('pageEdit.unsavedWarning'))) {
+      navigate(`/page/${slug}`)
+    }
+  }, [dirty, t, navigate, slug])
 
   useEffect(() => {
     getPage(slug).then((p) => {
@@ -279,7 +285,15 @@ export default function PageEdit() {
     return () => window.removeEventListener('keydown', handler)
   }, [handleSave])
 
-  if (!page) return <div className="text-text-secondary">{t('common.loading')}</div>
+  // Gate on the loaded page matching the current slug. React Router keeps
+  // PageEdit mounted across slug transitions, so while navigating A→B the
+  // still-loaded page is A (page.slug !== slug); showing the loader unmounts
+  // the uncontrolled Milkdown editor until B's content arrives, so a save can
+  // never write the previous page's body onto the new one. (Editor also keys
+  // on slug as a second guard.)
+  if (!page || page.slug !== slug) {
+    return <div className="text-text-secondary">{t('common.loading')}</div>
+  }
 
   return (
     <div className={showPreview ? 'edit-split-root' : 'max-w-4xl mx-auto'}>
@@ -344,6 +358,7 @@ export default function PageEdit() {
         <div className={showPreview ? 'edit-split-editor' : ''}>
           <div className="bg-surface rounded-xl shadow-sm border border-border min-h-[500px]">
             <Editor
+              key={slug}
               ref={editorRef}
               defaultValue={content}
               onChange={setContent}
@@ -422,7 +437,7 @@ export default function PageEdit() {
           </svg>
         </button>
         <button
-          onClick={() => navigate(`/page/${slug}`)}
+          onClick={handleCancel}
           className="fab-btn fab-btn-secondary"
         >
           {t('pageEdit.cancel')}

--- a/frontend/src/pages/PageView.jsx
+++ b/frontend/src/pages/PageView.jsx
@@ -105,7 +105,14 @@ export default function PageView() {
     return () => { cancelled = true }
   }, [slug, getPage, fetchPageTags, checkBookmark, navigate, isGuest])
 
+  const watchBusy = useRef(false)
+  const bookmarkBusy = useRef(false)
+
   const handleToggleWatch = async () => {
+    // Guard against double-clicks: a second request in flight can desync
+    // watching/watcherCount from the server.
+    if (watchBusy.current) return
+    watchBusy.current = true
     try {
       if (watching) {
         await api.delete(`/pages/${slug}/watch`)
@@ -118,6 +125,8 @@ export default function PageView() {
       }
     } catch (err) {
       console.error('Toggle watch failed:', err)
+    } finally {
+      watchBusy.current = false
     }
   }
 
@@ -129,13 +138,19 @@ export default function PageView() {
   }
 
   const handleToggleBookmark = async () => {
-    if (bookmarked) {
-      await removeBookmark(slug)
-    } else {
-      await addBookmark(slug)
+    if (bookmarkBusy.current) return
+    bookmarkBusy.current = true
+    try {
+      if (bookmarked) {
+        await removeBookmark(slug)
+      } else {
+        await addBookmark(slug)
+      }
+      setBookmarked(!bookmarked)
+      fetchBookmarks()
+    } finally {
+      bookmarkBusy.current = false
     }
-    setBookmarked(!bookmarked)
-    fetchBookmarks()
   }
 
   const handleAddTag = async (e) => {

--- a/frontend/src/store/useAuth.js
+++ b/frontend/src/store/useAuth.js
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import api from '../api/client'
 import useSettings from './useSettings'
+import useChat from './useChat'
 import { setGuestMode } from '../lib/authState'
 
 // Synthetic user used when ANONYMOUS_READ is on and the visitor has no
@@ -30,6 +31,9 @@ const useAuth = create((set) => ({
   logout: async () => {
     await api.post('/auth/logout').catch(() => {})
     setGuestMode(false)
+    // Drop per-user client state that would otherwise linger for the next
+    // account signing in on the same tab (SPA logout does no full reload).
+    useChat.getState().reset()
     set({ user: null, isAuthenticated: false })
   },
 
@@ -38,11 +42,18 @@ const useAuth = create((set) => ({
       const res = await api.get('/auth/me')
       setGuestMode(false)
       set({ user: res.data, isAuthenticated: true, loading: false })
-    } catch {
-      // /auth/me 401 means "no real session". Whether to fall back to a
-      // guest viewer depends on the server-side ANONYMOUS_READ flag, which
-      // ships in /api/settings. Make sure settings have loaded first so the
-      // boot sequence doesn't race and miscategorise a guest as logged-out.
+    } catch (err) {
+      // Only a real 401 means "no session". A transient network blip or 5xx
+      // must NOT be treated as logged-out — that would silently sign a valid
+      // user out until they reload. Leave auth state untouched in that case.
+      if (err?.response && err.response.status !== 401) {
+        set({ loading: false })
+        return
+      }
+      // 401 → no real session. Whether to fall back to a guest viewer depends
+      // on the server-side ANONYMOUS_READ flag, which ships in /api/settings.
+      // Make sure settings have loaded first so the boot sequence doesn't race
+      // and miscategorise a guest as logged-out.
       const settings = useSettings.getState()
       if (!settings.loaded) {
         await settings.fetch()

--- a/frontend/src/store/useAuth.test.js
+++ b/frontend/src/store/useAuth.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import useAuth from './useAuth'
 import useSettings from './useSettings'
+import useChat from './useChat'
 import { isGuestMode } from '../lib/authState'
 
 // Mock the API client
@@ -85,6 +86,29 @@ describe('useAuth Store', () => {
     // (CSRF-y operations, AI chat, profile edit) treats guest as logged-out.
     expect(result.current.isAuthenticated).toBe(false)
     expect(isGuestMode()).toBe(true)
+  })
+
+  it('should NOT log the user out on a transient (non-401) error', async () => {
+    // A logged-in user hits a 500 / network blip on /auth/me at boot.
+    const mockUser = { id: 1, username: 'admin', role: 'admin' }
+    client.get.mockResolvedValueOnce({ data: mockUser })
+    const { result } = renderHook(() => useAuth())
+    await act(async () => { await result.current.checkAuth() })
+    expect(result.current.user).toEqual(mockUser)
+
+    client.get.mockRejectedValueOnce({ response: { status: 500 } })
+    await act(async () => { await result.current.checkAuth() })
+
+    // Session preserved — a transient failure must not sign the user out.
+    expect(result.current.user).toEqual(mockUser)
+    expect(result.current.isAuthenticated).toBe(true)
+  })
+
+  it('should reset chat history on logout', async () => {
+    useChat.setState({ messages: [{ role: 'user', content: 'secret question' }] })
+    const { result } = renderHook(() => useAuth())
+    await act(async () => { await result.current.logout() })
+    expect(useChat.getState().messages).toEqual([])
   })
 
   it('should clear guest mode after a real login', async () => {

--- a/frontend/src/store/useChat.js
+++ b/frontend/src/store/useChat.js
@@ -35,6 +35,14 @@ const useChat = create((set, get) => ({
 
   clearHistory: () => set({ messages: [], error: null }),
 
+  // Full reset for logout: abort any in-flight stream and drop conversation
+  // state so the next user can't see the previous user's chat history.
+  reset: () => {
+    const ctrl = get().abortController
+    if (ctrl) ctrl.abort()
+    set({ messages: [], error: null, isStreaming: false, abortController: null })
+  },
+
   stopStreaming: () => {
     const ctrl = get().abortController
     if (ctrl) ctrl.abort()


### PR DESCRIPTION
This PR bundles three major improvement passes: security hardening, correctness fixes, and new webhook functionality.

## Security Hardening

**Media upload XSS prevention**: File extensions are now derived from the validated MIME type, not the attacker-controlled filename. A `text/plain` upload named `evil.html` is stored as `.txt` and served as `application/octet-stream` with `attachment` disposition, preventing stored XSS. Known-safe image types (PNG, JPEG, GIF, WebP) are still served inline with explicit `Content-Type`; SVG is served with `attachment` to prevent top-level script execution.

**Activity feed leak fix**: Non-admin users can no longer enumerate group names, membership changes, or other users' API token names via `/api/activity`. Group/token activity is now admin-only; non-admins see only page activity for pages they can read.

**Production deployment safety**: The app now refuses to start on internet-facing deployments (detected via `COOKIE_SECURE`, non-localhost `PUBLIC_BASE_URL`, or explicit `ALLOWED_ORIGINS`) if `SECRET_KEY` or `ADMIN_PASS` are set to insecure defaults. Localhost dev still warns loudly but boots.

**Login rate limiter memory bounds**: The in-memory rate limiter now evicts oldest-touched IP entries once the dict exceeds 10,000 IPs, preventing memory leaks from IP-rotating attackers.

**Proxy IP trust fix**: `TRUST_PROXY_HOPS` now correctly reads from the right of `X-Forwarded-For` (the entry appended by your own proxy), not the left (client-supplied, forgeable).

## Correctness Fixes

**Page list pagination stability**: Added `id DESC` tiebreaker to the `ORDER BY` clause so pages sharing the same `sort_order` and `updated_at` don't duplicate or skip across LIMIT/OFFSET boundaries.

**Parent page validation**: `PUT /api/pages/{slug}` now validates that a new parent exists and is not soft-deleted before applying the FK constraint, surfacing a clear 400 instead of an opaque 500.

**Backlink survival across trash/restore**: Backlinks are now preserved when the target page is trashed, the source is re-saved, and the target is restored. The wikilink parser deliberately does NOT skip soft-deleted targets during re-indexing.

**Revert requires base_version**: `POST /api/pages/{slug}/revert/{version}` now rejects requests missing `base_version` with a 400 error (no silent fallback), matching the optimistic-lock contract of `PUT /api/pages/{slug}`.

**Deactivated user lockout**: Added `is_active` column to users. A deactivated user (is_active=0) cannot log in and their existing JWT tokens stop resolving, enabling account suspension without data deletion.

**Diagram ownership validation**: Public pages can no longer exfiltrate diagrams owned by private pages; diagram inlining now checks `page_id` ownership.

**Comment ordering stability**: Added `id ASC` tiebreaker to comment ordering so same-second posts don't reorder across pagination.

**Double-click guards**: Watch and bookmark toggles now guard against in-flight requests to prevent desync with server state.

**Comment edit error handling**: Edit mode stays open if the update fails, preventing loss of unsaved edits.

**Logout state cleanup**: Logging out now resets per-user chat state so the next user signing in on the same tab doesn't see the previous user's conversation.

**Non-401 error handling**: The auth store no longer logs out on transient errors (500, network blips); only 401 triggers logout.

## Webhook Support

Added a new `WebhooksSection` admin panel component and backend endpoints:
- `GET/POST /api/webhooks` — list and create webhooks
- `PUT /api/webhooks/{id}` — toggle active status
- `DELETE /api/webhooks/{id}` — delete webhook

Webhooks POST a JSON payload to an external URL on page create/update/delete events. Supports event filtering (select which events trigger the hook) and enable/disable toggles. Includes i18n strings for English, Japanese, Korean

https://claude.ai/code/session_01WwrPN6d7VQBeWXtNpBnULy